### PR TITLE
Team metrics more

### DIFF
--- a/jira/jira_utils.py
+++ b/jira/jira_utils.py
@@ -1,5 +1,6 @@
 import os
 from datetime import datetime
+import argparse
 from jira import JIRA
 from jira.resources import Issue
 from dotenv import load_dotenv
@@ -10,8 +11,33 @@ load_dotenv()
 CUSTOM_FIELD_TEAM = os.getenv("CUSTOM_FIELD_TEAM")
 CUSTOM_FIELD_WORK_TYPE = os.getenv("CUSTOM_FIELD_WORK_TYPE")
 
+# Global variable for verbosity
+VERBOSE = False
 
-def get_jira_instance():
+
+def verbose_print(message):
+    if VERBOSE:
+        print(message)
+
+
+def parse_arguments():
+    # pylint: disable=global-statement
+    # Define the argument parser
+    parser = argparse.ArgumentParser(description="Process some tickets.")
+    parser.add_argument(
+        "-v", "--verbose", action="store_true", help="Enable verbose output"
+    )
+    parser.add_argument(
+        "-csv", action="store_true", help="Export the release data to a CSV file."
+    )
+    global VERBOSE
+    args = parser.parse_args()
+    VERBOSE = args.verbose
+    print(f"Verbose printing enabled: {VERBOSE}")
+    return args
+
+
+def get_jira_instance(verbose=False):
     """
     Create the jira instance
     An easy way to set up your environment variables is through your .zshrc or .bashrc file
@@ -81,10 +107,15 @@ def get_team(ticket):
 
 
 def extract_status_timestamps(issue):
+    # Extract the status change timestamps. Most recent first.
+    # To see the oldest first, reverse the order of histories (reverse(extract_status_timestamps(issue)))
     status_timestamps = []
     for history in issue.changelog.histories:
         for item in history.items:
             if item.field == "status":
+                verbose_print(
+                    f"{issue.key} processing status change: {item.toString}, timestammp: {history.created}"
+                )
                 status_timestamps.append(
                     {
                         "status": item.toString,


### PR DESCRIPTION
**Correction of 2 issues:** 

**Release date**
In case of rollback, the previous metric used the FIRST release date in the ticket history.  With the correction, we use the LATEST release date in the ticket history. 
example of tickets that were re-released  

- https://onfleet.atlassian.net/browse/ONF-3971
- https://onfleet.atlassian.net/browse/ONF-1762
- https://onfleet.atlassian.net/browse/INT-1842

**Code Review date**
In case it was TWICE in code review, then we want to measure from the FIRST TIME it was in code-review. 

https://onfleet.atlassian.net/browse/ONF-1762,  is one example. Which has multiple code-review times. 
First code review: February 22, 2023
Last code review: StatusFebruary 24 —> this is correct on the branch.  
INT-1952
BRANCH:  —> CORRECT
review start, 2024-08-27
Release: 2024-09-04 —> 96h === 7 days

MAIN: —>WRONG review start: 2024-08-29 Release: 2024-09-04 —> 40h —> 5 days. |


**CycleTime.py is the only script using this for now. Validation for the others is coming.** 

