### PR TITLE
Update python-ci.yml for fail if code coverage is below 50%

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -40,7 +40,7 @@ jobs:
         
     - name: Test with pytest
       run: |
-        pytest -v --junitxml=unittests.xml --cov=jira_metrics --cov-report=xml --cov-branch
+        pytest -v --junitxml=unittests.xml --cov=jira_metrics --cov-report=xml --cov-branch --cov-fail-under=50
 
     - name: Upload coverage reports to Codecov
       uses: codecov/codecov-action@v5


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update `python-ci.yml` to fail tests if code coverage is below 50%.
> 
>   - **CI Configuration**:
>     - Update `python-ci.yml` to include `--cov-fail-under=50` in the `pytest` command.
>     - Ensures tests fail if code coverage is below 50%.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=KjellKod%2Fmetrics-and-insights&utm_source=github&utm_medium=referral)<sup> for 2d836dfdc810dcffe65fd820dd517e2f2d107f0c. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->