### PR TITLE
adding debug information

### DIFF
--- a/git_metrics/developer_activity_insight.py
+++ b/git_metrics/developer_activity_insight.py
@@ -116,6 +116,8 @@ class MonthlyMetrics:
     total_changes: List[int]
     reviews_participated: int = 0
     review_response_times: List[float] = field(default_factory=list)
+    # Add PR details for debugging
+    pr_details: List[Tuple[str, int, float]] = field(default_factory=list)  # (repo, number, hours)
 
 
 @dataclass
@@ -416,16 +418,19 @@ class PRMetricsWriter(MetricsWriter):
             logger.debug("\nAverage Hours to Merge Calculation:")
             for month in months:
                 for author in authors:
-                    matching_prs = [pr for pr in pr_data if self._matches_month_and_author(pr, month, author)]
-                    if matching_prs:
-                        total_hours = sum(pr.hours_to_merge for pr in matching_prs)
-                        count = len(matching_prs)
-                        average = round(total_hours / count, 2)
+                    key = (month, author)
+                    if key in monthly_metrics:
+                        metrics = monthly_metrics[key]
+                        total_hours = sum(metrics.hours_to_merge)
+                        count = len(metrics.hours_to_merge)
+                        average = round(total_hours / count, 2) if count > 0 else 0
                         logger.debug(f"  {month} - {author}:")
                         logger.debug(f"    Total hours: {total_hours}")
                         logger.debug(f"    PR count: {count}")
                         logger.debug(f"    Average: {average}")
-                        logger.debug(f"    Individual PR hours: {[pr.hours_to_merge for pr in matching_prs]}")
+                        logger.debug(f"    Individual PRs:")
+                        for repo, number, hours in sorted(metrics.pr_details, key=lambda x: x[2], reverse=True):
+                            logger.debug(f"      {repo} #{number}: {hours:.2f} hours")
 
             self._write_metric_section(
                 writer,
@@ -609,6 +614,8 @@ class PRMetricsCollector:
             monthly_metrics[key].lines_added.append(pr.additions)
             monthly_metrics[key].lines_removed.append(pr.deletions)
             monthly_metrics[key].total_changes.append(pr.additions + pr.deletions)
+            # Store PR details for debugging
+            monthly_metrics[key].pr_details.append((pr.repo, pr.number, pr.hours_to_merge))
 
             # Process review data
             logger.debug(f"Processing reviews for PR #{pr.number} in {pr.repo}")

--- a/git_metrics/developer_activity_insight.py
+++ b/git_metrics/developer_activity_insight.py
@@ -420,7 +420,7 @@ class PRMetricsWriter(MetricsWriter):
             logger.debug("\nAverage Hours to Merge Calculation:")
             for month in months:
                 for author in authors:
-                    key = (month, author)
+                    key = (month, self.normalize_username(author))
                     if key in monthly_metrics:
                         metrics = monthly_metrics[key]
                         total_hours = sum(metrics.hours_to_merge)


### PR DESCRIPTION
when using the `--debug` option we should now see detailed output with PR number and the time between "created_at" to "merged_at (below with bogus numbers)
"
```
DEBUG:__main__:  2025-03 - KjellKod:
DEBUG:__main__:    Total hours: 1478.5
DEBUG:__main__:    PR count: 8
DEBUG:__main__:    Average: 184.81
DEBUG:__main__:    Individual PRs:
DEBUG:__main__:      KjellKod/g3log #25: 4.82 hours
DEBUG:__main__:           Created: 2025-03-05 09:15:30 MDT
DEBUG:__main__:           Merged:  2025-03-20 14:22:10 MDT
DEBUG:__main__:      KjellKod/metrics-and-insights #2: 5.5 hours
DEBUG:__main__:           Created: 2025-03-05 09:15:30 MDT
DEBUG:__main__:           Merged:  2025-03-20 14:22:10 MDT
etc
```

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds detailed debug logging for PR metrics, including PR number, creation, and merge times, when `--debug` is enabled.
> 
>   - **Debug Information**:
>     - Adds `created_at` and `merged_at` to `PRData`.
>     - Adds `pr_details` to `MonthlyMetrics` for storing detailed PR info.
>     - Enhances debug output in `write()` in `PRMetricsWriter` to include PR number, creation, and merge times.
>   - **Logging**:
>     - Logs detailed PR metrics when `--debug` is enabled, including individual PR hours, creation, and merge times.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=KjellKod%2Fmetrics-and-insights&utm_source=github&utm_medium=referral)<sup> for beeaeeecda31ab59fec6e86f8f65468e2b885e17. You can [customize](https://app.ellipsis.dev/KjellKod/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->