### PR TITLE
avoid missing epics just because they might have a jira status we aren't aware of

### DIFF
--- a/jira_metrics/epic_tracking.py
+++ b/jira_metrics/epic_tracking.py
@@ -52,12 +52,12 @@ if EPIC_LABELS and EPIC_LABELS.strip():
     if labels_list:  # Only add labels clause if we have actual labels
         labels_jql = ", ".join(f'"{label}"' for label in labels_list)
         default_jql = (
-            f'issuetype = Epic AND labels IN ({labels_jql}) AND status IN ("done", "released", "In Progress", "In Develop")'
+            f'issuetype = Epic AND labels IN ({labels_jql}) '
         )
     else:
-        default_jql = 'issuetype = Epic AND status IN ("done", "released", "In Progress", "In Develop")'
+        default_jql = 'issuetype = Epic'
 else:
-    default_jql = 'issuetype = Epic AND status IN ("done", "released", "In Progress", "In Develop")'
+    default_jql = 'issuetype = Epic'
 
 JQL_EPICS = os.environ.get("JIRA_JQL_EPICS", default_jql)
 
@@ -166,6 +166,7 @@ def search_jql(jql: str, fields: List[str], max_per_page: int = 100) -> List[Dic
 
 def get_epics() -> List[Dict[str, Any]]:
     fields = ["summary", "status"]
+    print(f"JQL to find epics: {JQL_EPICS}")
     issues = search_jql(JQL_EPICS, fields)
     return issues
 


### PR DESCRIPTION
we don't want to filter out epics in the jql if they are in a state that we aren't aware of
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Removes status filtering from JQL in `epic_tracking.py` to include all epics, adding a print statement for debugging.
> 
>   - **Behavior**:
>     - Removes status filtering from JQL query in `epic_tracking.py` to include all epics regardless of status.
>     - Adds a print statement in `get_epics()` to display the JQL query being used.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=KjellKod%2Fmetrics-and-insights&utm_source=github&utm_medium=referral)<sup> for 40a5dfdbb65bfe992d92bc37d5e1df55e00d93f8. You can [customize](https://app.ellipsis.dev/KjellKod/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->