### PR TITLE
first attempt at a 'flexible' cycle times

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,20 @@ Scripts for extracting and analyzing Jira metrics:
 - `released_tickets.py`: Track monthly released ticket counts
 - `jira_utils.py`: Helper utility module
 
+#### Cycle Time configuration
+`cycle_time.py` measures time between the first entry into a code review state and the earliest
+completion state. Completion states are configurable via the environment variable `COMPLETION_STATUSES`.
+
+Defaults:
+- Code review states: `{"code review", "in code review", "to review", "to code review", "in review", "in design review"}`
+- Completion states: `["released", "done"]`
+
+Override completion states (example for mobile team):
+```bash
+export COMPLETION_STATUSES="closed,done,to release,released"
+```
+The script prints the active code review and completion status sets at the start and end of execution.
+
 ## Environment Variables
 
 Create an `.env` file in the root directory with the following variables:

--- a/jira_metrics/cycle_time.py
+++ b/jira_metrics/cycle_time.py
@@ -256,14 +256,9 @@ def main():
     # Print measurement configuration (start)
     review_statuses = sorted(get_code_review_statuses())
     completion_statuses = get_completion_statuses()
-    print(
-        "Measuring cycle time between: FIRST code review entry and EARLIEST completion status (per configuration)."
-    )
+    print("Measuring cycle time between: FIRST code review entry and EARLIEST completion status (per configuration).")
     print(f"Code review statuses: {review_statuses}")
-    print(
-        "Completion statuses: "
-        f"{completion_statuses} (override via environment variable COMPLETION_STATUSES)"
-    )
+    print("Completion statuses: " f"{completion_statuses} (override via environment variable COMPLETION_STATUSES)")
     current_year = datetime.now().year
     start_date = f"{current_year}-01-01"
     end_date = f"{current_year}-12-31"
@@ -272,14 +267,9 @@ def main():
     cycle_times_per_month = calculate_monthly_cycle_time(projects, start_date, end_date)
     show_cycle_time_metrics(args.csv, cycle_times_per_month, args.verbose)
     # Print measurement configuration (end)
-    print(
-        "Completed cycle time measurement using: FIRST code review status and EARLIEST completion status."
-    )
+    print("Completed cycle time measurement using: FIRST code review status and EARLIEST completion status.")
     print(f"Code review statuses: {review_statuses}")
-    print(
-        "Completion statuses: "
-        f"{completion_statuses} (override via environment variable COMPLETION_STATUSES)"
-    )
+    print("Completion statuses: " f"{completion_statuses} (override via environment variable COMPLETION_STATUSES)")
 
 
 if __name__ == "__main__":

--- a/jira_metrics/cycle_time.py
+++ b/jira_metrics/cycle_time.py
@@ -51,7 +51,21 @@ def print_skip_issue(issue, team, month_display, reason):
 
 
 def business_time_spent_in_seconds(start, end):
-    """extract only the time spent during business hours from a jira time range -- only count 8h"""
+    """Extract only the time spent during business hours from a jira time range -- only count 8h per weekday.
+
+    Important: This function measures elapsed time capped at 8 hours per weekday (Mon-Fri).
+    It does NOT track specific business hours (e.g., 9am-5pm).
+
+    When advancing to the next day (e.g., skipping a weekend), the time resets to midnight (00:00).
+    Example: Start Sunday 9am, End Monday 2pm → counts from Monday 00:00 to 14:00 = 8 hours (capped).
+
+    Args:
+        start: datetime object for the start time
+        end: datetime object for the end time
+
+    Returns:
+        int: Total business seconds (capped at 8 hours per weekday)
+    """
     weekdays = [0, 1, 2, 3, 4]  # Monday to Friday
     total_business_seconds = 0
     seconds_in_workday = 8 * 60 * 60  # 8 hours * 60 minutes * 60 seconds
@@ -71,6 +85,7 @@ def business_time_spent_in_seconds(start, end):
                 total_business_seconds += min(remaining_time_on_last_day.total_seconds(), seconds_in_workday)
                 break
         else:
+            # Skip weekend: advance to next day starting at midnight
             current += timedelta(days=1)
             current = current.replace(hour=0, minute=0)
 

--- a/jira_metrics/cycle_time.py
+++ b/jira_metrics/cycle_time.py
@@ -273,7 +273,7 @@ def main():
     completion_statuses = get_completion_statuses()
     print("Measuring cycle time between: FIRST code review entry and EARLIEST completion status (per configuration).")
     print(f"Code review statuses: {review_statuses}")
-    print("Completion statuses: " f"{completion_statuses} (override via environment variable COMPLETION_STATUSES)")
+    print(f"Completion statuses: {completion_statuses} (override via environment variable COMPLETION_STATUSES)")
     current_year = datetime.now().year
     start_date = f"{current_year}-01-01"
     end_date = f"{current_year}-12-31"

--- a/jira_metrics/jira_utils.py
+++ b/jira_metrics/jira_utils.py
@@ -51,6 +51,36 @@ def parse_common_arguments(parser=None):
     return args
 
 
+def get_completion_statuses():
+    """
+    Return the list of configured completion statuses used to determine the end of cycle time.
+
+    Defaults to ["released", "done"]. Teams can override via the COMPLETION_STATUSES
+    environment variable with a comma-separated list, e.g. "closed,done,to release,released".
+    """
+    completion_statuses_str = os.getenv("COMPLETION_STATUSES", "released,done")
+    completion_statuses = [s.strip().lower() for s in completion_statuses_str.split(",") if s.strip()]
+    verbose_print(f"Using completion statuses: {completion_statuses}")
+    return completion_statuses
+
+
+def get_code_review_statuses():
+    """
+    Return the set of statuses considered as entering code review.
+
+    Currently static, but centralized so callers can print and so we can
+    adjust in one place later if needed.
+    """
+    return {
+        "code review",
+        "in code review",
+        "to review",
+        "to code review",
+        "in review",
+        "in design review",
+    }
+
+
 def get_jira_instance():
     """
     Create and verify the jira instance
@@ -647,15 +677,9 @@ def extract_status_timestamps(issue):
 
 def interpret_status_timestamps(status_timestamps):
     # Interpret the status change timestamps to determine the status timestamps that is of value
-    # example: released --> the LAST release date, code review --> the FIRST code review date
-    code_review_statuses = {
-        "code review",
-        "in code review",
-        "to review",
-        "to code review",
-        "in review",
-        "in design review",
-    }
+    # code review --> the FIRST code review date
+    # completion   --> the EARLIEST occurrence among configured completion statuses
+    code_review_statuses = get_code_review_statuses()
     extracted_statuses = {
         JiraStatus.CODE_REVIEW.value: None,
         JiraStatus.RELEASED.value: None,
@@ -668,18 +692,29 @@ def interpret_status_timestamps(status_timestamps):
         timestamp = entry["timestamp"]
         if status.lower() in code_review_statuses and not extracted_statuses[JiraStatus.CODE_REVIEW.value]:
             extracted_statuses[JiraStatus.CODE_REVIEW.value] = timestamp
-            # we might want to change this later, but for now we only check for code review
+            # we only check for code review for now. We might want to change this later.
             break
 
-    # look at the histories in reverse-chronological order to find the LAST time it was released.
-    for entry in status_timestamps:
-        status = entry["status"]
+    # Determine the earliest completion status based on configuration
+    completion_statuses = get_completion_statuses()
+    earliest_completion_timestamp = None
+    earliest_completion_name = None
+
+    # status_timestamps is most-recent-first; iterate reversed to get oldest-first
+    for entry in reversed(status_timestamps):
+        status = entry["status"].lower()
         timestamp = entry["timestamp"]
-        if status.lower() == "released" and not extracted_statuses[JiraStatus.RELEASED.value]:
-            extracted_statuses[JiraStatus.RELEASED.value] = timestamp
+        if status in completion_statuses:
+            earliest_completion_timestamp = timestamp
+            earliest_completion_name = status
             break
-        if status.lower() == "done" and not extracted_statuses[JiraStatus.DONE.value]:
-            extracted_statuses[JiraStatus.DONE.value] = timestamp
-            break
+
+    # For compatibility, set both RELEASED and DONE to the earliest completion timestamp
+    if earliest_completion_timestamp:
+        extracted_statuses[JiraStatus.RELEASED.value] = earliest_completion_timestamp
+        extracted_statuses[JiraStatus.DONE.value] = earliest_completion_timestamp
+        verbose_print(
+            f"Earliest completion status detected: '{earliest_completion_name}' at {earliest_completion_timestamp}"
+        )
 
     return extracted_statuses

--- a/jira_metrics/tests/test_cycle_time.py
+++ b/jira_metrics/tests/test_cycle_time.py
@@ -118,7 +118,7 @@ class TestProcessChangelog(unittest.TestCase):
 
 class TestBusinessTimeCalculations(unittest.TestCase):
     """Tests for business_time_spent_in_seconds function.
-    
+
     This function calculates time spent during business hours (8 hours per weekday).
     Key behaviors:
     - Only counts Monday-Friday

--- a/jira_metrics/tests/test_cycle_time.py
+++ b/jira_metrics/tests/test_cycle_time.py
@@ -10,7 +10,7 @@ from jira.resources import Issue
 # Add the parent directory to the Python path
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 # pylint: disable=wrong-import-position,import-error
-from cycle_time import process_changelog
+from cycle_time import process_changelog, business_time_spent_in_seconds
 
 
 # Define the PST timezone
@@ -114,6 +114,169 @@ class TestProcessChangelog(unittest.TestCase):
         expected_released_timestamp = datetime.strptime("2024-01-05T15:00:00.000-0800", "%Y-%m-%dT%H:%M:%S.%f%z")
         self.assertEqual(code_review_timestamp, expected_code_review_timestamp)
         self.assertEqual(released_timestamp, expected_released_timestamp)
+
+
+class TestBusinessTimeCalculations(unittest.TestCase):
+    """Tests for business_time_spent_in_seconds function.
+    
+    This function calculates time spent during business hours (8 hours per weekday).
+    Key behaviors:
+    - Only counts Monday-Friday
+    - Caps at 8 hours (28800 seconds) per day
+    - Handles multi-day spans
+    - Excludes weekends
+    """
+
+    def test_same_day_within_8_hours(self):
+        """Test calculation for same day, within 8 hour cap."""
+        # Monday Jan 2, 2023: 9am to 1pm = 4 hours
+        start = datetime(2023, 1, 2, 9, 0)  # Monday
+        end = datetime(2023, 1, 2, 13, 0)
+        result = business_time_spent_in_seconds(start, end)
+        expected = 4 * 3600  # 4 hours
+        self.assertEqual(result, expected, f"Expected {expected}, got {result}")
+
+    def test_same_day_exceeds_8_hours(self):
+        """Test that same day duration is capped at 8 hours."""
+        # Monday Jan 2, 2023: 9am to 11pm = should cap at 8 hours
+        start = datetime(2023, 1, 2, 9, 0)  # Monday
+        end = datetime(2023, 1, 2, 23, 0)
+        result = business_time_spent_in_seconds(start, end)
+        expected = 8 * 3600  # 8 hours (capped)
+        self.assertEqual(result, expected, f"Expected {expected}, got {result}")
+
+    def test_two_consecutive_weekdays(self):
+        """Test calculation spanning two consecutive weekdays."""
+        # Monday Jan 2, 2023 2pm to Tuesday Jan 3, 2023 10am
+        # Monday: 2pm to end of day = min(10 hours, 8) = 8 hours
+        # Tuesday: start to 10am = min(10 hours, 8) = 8 hours
+        # Total = 16 hours
+        start = datetime(2023, 1, 2, 14, 0)  # Monday 2pm
+        end = datetime(2023, 1, 3, 10, 0)  # Tuesday 10am
+        result = business_time_spent_in_seconds(start, end)
+        expected = 16 * 3600  # 16 hours
+        self.assertEqual(result, expected, f"Expected {expected}, got {result}")
+
+    def test_spans_weekend(self):
+        """Test that weekends are excluded from calculation."""
+        # Friday Jan 6, 2023 2pm to Monday Jan 9, 2023 10am
+        # Friday: 2pm to end of day = min(10 hours, 8) = 8 hours
+        # Saturday: 0 hours (weekend)
+        # Sunday: 0 hours (weekend)
+        # Monday: start to 10am = min(10 hours, 8) = 8 hours
+        # Total = 16 hours
+        start = datetime(2023, 1, 6, 14, 0)  # Friday 2pm
+        end = datetime(2023, 1, 9, 10, 0)  # Monday 10am
+        result = business_time_spent_in_seconds(start, end)
+        expected = 16 * 3600  # 16 hours
+        self.assertEqual(result, expected, f"Expected {expected}, got {result}")
+
+    def test_starts_on_saturday(self):
+        """Test that starting on Saturday only counts from Monday."""
+        # Saturday Jan 7, 2023 9am to Monday Jan 9, 2023 5pm
+        # Saturday: 0 hours (weekend)
+        # Sunday: 0 hours (weekend)
+        # Monday: start to 5pm = min(8 hours, 8) = 8 hours
+        start = datetime(2023, 1, 7, 9, 0)  # Saturday
+        end = datetime(2023, 1, 9, 17, 0)  # Monday
+        result = business_time_spent_in_seconds(start, end)
+        expected = 8 * 3600  # 8 hours
+        self.assertEqual(result, expected, f"Expected {expected}, got {result}")
+
+    def test_starts_on_sunday(self):
+        """Test that starting on Sunday only counts from Monday at midnight."""
+        # Sunday Jan 8, 2023 9am to Monday Jan 9, 2023 2pm
+        # Sunday: 0 hours (weekend, skipped)
+        # Monday: midnight to 2pm = 14 hours, capped at 8 hours = 8 hours
+        start = datetime(2023, 1, 8, 9, 0)  # Sunday
+        end = datetime(2023, 1, 9, 14, 0)  # Monday
+        result = business_time_spent_in_seconds(start, end)
+        expected = 8 * 3600  # 8 hours (capped)
+        self.assertEqual(result, expected, f"Expected {expected}, got {result}")
+
+    def test_entire_weekend(self):
+        """Test that an entire weekend returns 0 hours."""
+        # Saturday Jan 7, 2023 9am to Sunday Jan 8, 2023 5pm
+        start = datetime(2023, 1, 7, 9, 0)  # Saturday
+        end = datetime(2023, 1, 8, 17, 0)  # Sunday
+        result = business_time_spent_in_seconds(start, end)
+        expected = 0  # No business hours on weekend
+        self.assertEqual(result, expected, f"Expected {expected}, got {result}")
+
+    def test_full_work_week(self):
+        """Test calculation for a full work week."""
+        # Monday Jan 2, 2023 9am to Friday Jan 6, 2023 5pm
+        # Each day capped at 8 hours = 5 days * 8 hours = 40 hours
+        start = datetime(2023, 1, 2, 9, 0)  # Monday
+        end = datetime(2023, 1, 6, 17, 0)  # Friday
+        result = business_time_spent_in_seconds(start, end)
+        expected = 40 * 3600  # 40 hours
+        self.assertEqual(result, expected, f"Expected {expected}, got {result}")
+
+    def test_two_full_weeks(self):
+        """Test calculation spanning two weeks with weekends."""
+        # Monday Jan 2, 2023 to Friday Jan 13, 2023
+        # Week 1: Mon-Fri = 40 hours
+        # Weekend: 0 hours
+        # Week 2: Mon-Fri = 40 hours
+        # Total = 80 hours
+        start = datetime(2023, 1, 2, 9, 0)  # Monday
+        end = datetime(2023, 1, 13, 17, 0)  # Friday (next week)
+        result = business_time_spent_in_seconds(start, end)
+        expected = 80 * 3600  # 80 hours
+        self.assertEqual(result, expected, f"Expected {expected}, got {result}")
+
+    def test_very_short_duration(self):
+        """Test calculation for very short duration (less than 1 hour)."""
+        # Monday Jan 2, 2023: 9am to 9:30am = 30 minutes
+        start = datetime(2023, 1, 2, 9, 0)  # Monday
+        end = datetime(2023, 1, 2, 9, 30)
+        result = business_time_spent_in_seconds(start, end)
+        expected = 30 * 60  # 30 minutes
+        self.assertEqual(result, expected, f"Expected {expected}, got {result}")
+
+    def test_start_equals_end(self):
+        """Test that same start and end time returns 0."""
+        # Monday Jan 2, 2023: 9am to 9am
+        start = datetime(2023, 1, 2, 9, 0)  # Monday
+        end = datetime(2023, 1, 2, 9, 0)
+        result = business_time_spent_in_seconds(start, end)
+        expected = 0
+        self.assertEqual(result, expected, f"Expected {expected}, got {result}")
+
+    def test_end_of_day_boundary(self):
+        """Test calculation ending at day boundary."""
+        # Monday Jan 2, 2023: 9am to 11:59pm = should cap at 8 hours
+        start = datetime(2023, 1, 2, 9, 0)  # Monday
+        end = datetime(2023, 1, 2, 23, 59)
+        result = business_time_spent_in_seconds(start, end)
+        expected = 8 * 3600  # 8 hours (capped)
+        self.assertEqual(result, expected, f"Expected {expected}, got {result}")
+
+    def test_partial_first_day_full_second_day(self):
+        """Test with partial first day and full second day."""
+        # Monday Jan 2, 2023 2pm to Tuesday Jan 3, 2023 11pm
+        # Monday: 2pm to end of day = min(10 hours, 8) = 8 hours
+        # Tuesday: all day = 8 hours
+        # Total = 16 hours
+        start = datetime(2023, 1, 2, 14, 0)  # Monday 2pm
+        end = datetime(2023, 1, 3, 23, 0)  # Tuesday 11pm
+        result = business_time_spent_in_seconds(start, end)
+        expected = 16 * 3600  # 16 hours
+        self.assertEqual(result, expected, f"Expected {expected}, got {result}")
+
+    def test_three_weekdays_in_a_row(self):
+        """Test calculation spanning three consecutive weekdays."""
+        # Monday Jan 2 3pm to Wednesday Jan 4 1pm
+        # Monday: 3pm to end = min(9 hours, 8) = 8 hours
+        # Tuesday: full day = 8 hours
+        # Wednesday: start to 1pm = min(1pm, 8) = 8 hours
+        # Total = 24 hours
+        start = datetime(2023, 1, 2, 15, 0)  # Monday 3pm
+        end = datetime(2023, 1, 4, 13, 0)  # Wednesday 1pm
+        result = business_time_spent_in_seconds(start, end)
+        expected = 24 * 3600  # 24 hours
+        self.assertEqual(result, expected, f"Expected {expected}, got {result}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
first attempt at a 'flexible' cycle time that allows for very differnt approach to 'end state' statuses
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Introduces configurable cycle time completion statuses and enhances logging and testing for business time calculations.
> 
>   - **Behavior**:
>     - `cycle_time.py` now allows configuration of completion states via `COMPLETION_STATUSES` environment variable.
>     - Logs active code review and completion status sets at start and end of execution in `main()`.
>   - **Functions**:
>     - Adds `get_completion_statuses()` and `get_code_review_statuses()` in `jira_utils.py` for retrieving status configurations.
>     - Refactors `interpret_status_timestamps()` in `jira_utils.py` to use the most recent completion status.
>     - Adds `print_skip_issue()` in `cycle_time.py` for standardized skip logging.
>   - **Tests**:
>     - Adds `TestBusinessTimeCalculations` in `test_cycle_time.py` to test `business_time_spent_in_seconds()` for various scenarios including weekends and multi-day spans.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=KjellKod%2Fmetrics-and-insights&utm_source=github&utm_medium=referral)<sup> for 667f892def98af4c20aab5e2edab2d98d24bc1ed. You can [customize](https://app.ellipsis.dev/KjellKod/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->