### PR TITLE
Add per-month merged PR counter for an entire GitHub organization

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ If you only need local analysis artifacts, MCP/Sheets access is not required. If
 │   ├── repo_commit_report.sh           # Generate commit reports for multiple repos
 │   ├── code_review_metrics.py          # Analyze code review patterns and timing
 │   ├── ci_pr_performance_metrics.py    # Analyze PR and CI metrics
+│   ├── org_merged_prs_per_month.py     # Count org-wide merged PRs per month
 │   ├── active_devs_one_off.py          # Track active developers
 │   ├── active_repositories_in_organization.py  # Identify active repositories
 │
@@ -107,6 +108,7 @@ Scripts for analyzing GitHub repository metrics and developer activity. For deta
 - `code_review_metrics.py`: Analyze code review patterns and timing
 - `ci_pr_performance_metrics.py`: Track CI performance metrics for PRs
 - `ci_maturity_report.py`: Grade repository CI maturity across a GitHub user or organization profile
+- `org_merged_prs_per_month.py`: Count org-wide merged PRs per month, with optional per-repo and LOC totals
 - `active_devs_one_off.py`: Identify and analyze active developers
 - `active_repositories_in_organization.py`: Identify and analyze active repositories
 

--- a/git_metrics/README.md
+++ b/git_metrics/README.md
@@ -122,6 +122,45 @@ When cached repository results are reused, table and CSV runs print a reminder t
 Table and CSV output include likely responsible people based on recent distinct merged PR authors, with public profile names when available.
 JSON output includes per-repo scores, grade labels, responsible people, category evidence, skipped repositories, and rate-limit wait metadata.
 
+### org_merged_prs_per_month.py
+Counts merged PRs per month across an entire GitHub organization. Count-only mode uses GitHub Search `total_count`, so each month is one REST call. Optional modes can add per-repo counts and total additions/deletions for each month.
+
+```bash
+python3 -m git_metrics.org_merged_prs_per_month \
+  --owner example-org \
+  --from 2025-01-01 \
+  --to 2026-04-30
+```
+
+Verbose per-repo breakdown plus monthly LOC totals:
+
+```bash
+python3 -m git_metrics.org_merged_prs_per_month \
+  --owner example-org \
+  --from 2025-01-01 \
+  --to 2026-04-30 \
+  --verbose \
+  --loc
+```
+
+Options:
+- `--owner OWNER` GitHub organization login (falls back to `GITHUB_METRIC_OWNER_OR_ORGANIZATION`). Searches are org-scoped with `org:<owner>`; user accounts are not supported.
+- `--from YYYY-MM-DD` Inclusive start date.
+- `--to YYYY-MM-DD` Inclusive end date. Future dates are rejected to avoid misleading zero-data rows.
+- `--token-env ENV` Environment variable containing a GitHub token (default: `GITHUB_TOKEN_READONLY_WEB`).
+- `--format table|json|csv` Output format (default: `table`).
+- `-v, --verbose` Include per-repo merged PR counts for each month.
+- `-l, --loc` Include total additions and deletions for each month.
+- `--debug` Enable debug logging.
+
+Help and invocation notes:
+- Run `python3 -m git_metrics.org_merged_prs_per_month --help` from the repository root for full examples.
+- Direct script-path help also works: `python3 git_metrics/org_merged_prs_per_month.py --help`.
+- When using Python module mode, put the module name immediately after `-m`, then pass CLI flags: `python3 -m git_metrics.org_merged_prs_per_month --owner example-org ...`.
+- Use `-v` or `--verbose`; `--v` is not a valid flag.
+
+When GitHub Search returns more than 1000 results for a window, verbose and LOC modes recursively split the date range so counts stay attributable. Counts are token-scoped, so a token without private-repo access will under-report private repositories.
+
 ### active_devs_one_off.py
 One-time script to identify and analyze active developers in the repository.
 

--- a/git_metrics/org_merged_prs_per_month.py
+++ b/git_metrics/org_merged_prs_per_month.py
@@ -1,0 +1,363 @@
+#!/usr/bin/env python3
+"""Count merged PRs per month across an entire GitHub organization.
+
+Uses the Search API at org scope and reads ``total_count`` directly, so each
+month is one cheap REST call regardless of how many PRs were merged. Backoff
+on 429 / secondary-rate-limit responses is delegated to the hardened
+``GitHubClient`` from ``git_metrics.ci_maturity_report``.
+
+Examples::
+
+    python -m git_metrics.org_merged_prs_per_month \
+        --from 2025-05-01 --to 2026-05-08
+
+    python -m git_metrics.org_merged_prs_per_month \
+        --from 2025-01-01 --to 2025-12-31 --format csv > merged_prs.csv
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import io
+import json
+import logging
+import os
+import sys
+import time
+from dataclasses import dataclass
+from datetime import date, datetime, timedelta
+from typing import Any
+
+from dotenv import load_dotenv
+
+from git_metrics.ci_maturity_report import DEFAULT_TOKEN_ENV, GitHubClient, load_token
+from git_metrics.throughput_collect import MonthWindow, month_windows
+
+
+load_dotenv()
+
+ENV_OWNER_KEY = "GITHUB_METRIC_OWNER_OR_ORGANIZATION"
+INTER_REQUEST_PAUSE_SECONDS = 0.25
+SEARCH_RESULT_CAP = 1000
+SEARCH_PAGE_SIZE = 100
+
+
+@dataclass(frozen=True)
+class MonthlyMergedCount:
+    month: str
+    window_start: date
+    window_end: date
+    merged_prs: int
+    per_repo: dict[str, int] | None = None
+
+
+@dataclass(frozen=True)
+class MergedPrReport:
+    owner: str
+    range_start: date
+    range_end: date
+    rows: tuple[MonthlyMergedCount, ...]
+    rate_limit_events: tuple[dict[str, Any], ...]
+
+    @property
+    def total(self) -> int:
+        return sum(row.merged_prs for row in self.rows)
+
+
+def parse_iso_date(value: str) -> date:
+    return datetime.strptime(value, "%Y-%m-%d").date()
+
+
+def build_argument_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Count merged PRs per month across an entire GitHub organization.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument(
+        "--from",
+        dest="from_date",
+        required=True,
+        type=parse_iso_date,
+        help="Inclusive start date (YYYY-MM-DD). Example: --from 2025-05-01",
+    )
+    parser.add_argument(
+        "--to",
+        dest="to_date",
+        required=True,
+        type=parse_iso_date,
+        help="Inclusive end date (YYYY-MM-DD). Example: --to 2026-05-08",
+    )
+    parser.add_argument(
+        "--owner",
+        default=argparse.SUPPRESS,
+        help=f"GitHub organization or user. Defaults to ${ENV_OWNER_KEY}.",
+    )
+    parser.add_argument(
+        "--token-env",
+        default=DEFAULT_TOKEN_ENV,
+        help="Environment variable holding the GitHub token.",
+    )
+    parser.add_argument(
+        "--format",
+        choices=["table", "json", "csv"],
+        default="table",
+        help="Output format.",
+    )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help="Also report per-repo merged PR counts per month. Costs extra API calls (paginates search results).",
+    )
+    parser.add_argument("--debug", action="store_true", help="Enable debug logging.")
+    return parser
+
+
+def _search_query(owner: str, range_start: date, range_end: date) -> str:
+    return f"org:{owner} is:pr is:merged merged:{range_start.isoformat()}..{range_end.isoformat()}"
+
+
+def count_merged_prs_for_window(
+    client: GitHubClient,
+    owner: str,
+    window: MonthWindow,
+) -> int:
+    """Return the total merged PR count for ``owner`` within ``window``."""
+
+    payload = client.get_json(
+        "/search/issues",
+        params={"q": _search_query(owner, window.start, window.end), "per_page": 1},
+    )
+    return int(payload.get("total_count") or 0)
+
+
+def per_repo_counts_for_window(
+    client: GitHubClient,
+    owner: str,
+    window: MonthWindow,
+) -> tuple[dict[str, int], int]:
+    """Return ``({repo: count}, total)`` for merged PRs in ``window``.
+
+    Paginates the Search API. When the window has more than the 1000-result
+    Search cap, the window is halved recursively so every PR is attributable.
+    """
+
+    return _per_repo_counts_for_range(client, owner, window.start, window.end)
+
+
+def _per_repo_counts_for_range(
+    client: GitHubClient,
+    owner: str,
+    range_start: date,
+    range_end: date,
+) -> tuple[dict[str, int], int]:
+    query = _search_query(owner, range_start, range_end)
+    head = client.get_json("/search/issues", params={"q": query, "per_page": 1})
+    total = int(head.get("total_count") or 0)
+
+    if total > SEARCH_RESULT_CAP:
+        if range_start >= range_end:
+            raise RuntimeError(
+                f"GitHub search returned more than {SEARCH_RESULT_CAP} merged PRs for "
+                f"org:{owner} on {range_start.isoformat()}; cannot disambiguate per repo"
+            )
+        midpoint = range_start + timedelta(days=(range_end - range_start).days // 2)
+        left_counts, left_total = _per_repo_counts_for_range(client, owner, range_start, midpoint)
+        right_counts, right_total = _per_repo_counts_for_range(client, owner, midpoint + timedelta(days=1), range_end)
+        merged: dict[str, int] = dict(left_counts)
+        for repo, count in right_counts.items():
+            merged[repo] = merged.get(repo, 0) + count
+        return merged, left_total + right_total
+
+    counts: dict[str, int] = {}
+    if total == 0:
+        return counts, 0
+
+    page = 1
+    max_pages = (SEARCH_RESULT_CAP // SEARCH_PAGE_SIZE) + 1
+    while page <= max_pages:
+        payload = client.get_json(
+            "/search/issues",
+            params={"q": query, "per_page": SEARCH_PAGE_SIZE, "page": page},
+        )
+        items = payload.get("items") or []
+        for item in items:
+            repo_url = item.get("repository_url") or ""
+            repo_name = repo_url.rsplit("/", 1)[-1] if repo_url else ""
+            if not repo_name:
+                continue
+            counts[repo_name] = counts.get(repo_name, 0) + 1
+        if len(items) < SEARCH_PAGE_SIZE:
+            break
+        page += 1
+    return counts, total
+
+
+def collect_report(
+    client: GitHubClient,
+    owner: str,
+    range_start: date,
+    range_end: date,
+    *,
+    verbose: bool = False,
+    sleep_fn: Any = time.sleep,
+    pause_seconds: float = INTER_REQUEST_PAUSE_SECONDS,
+) -> MergedPrReport:
+    if range_end < range_start:
+        raise ValueError("--to must be on or after --from")
+
+    rows: list[MonthlyMergedCount] = []
+    windows = month_windows(range_start, range_end)
+    for index, window in enumerate(windows):
+        if index > 0 and pause_seconds > 0:
+            sleep_fn(pause_seconds)
+        if verbose:
+            per_repo, count = per_repo_counts_for_window(client, owner, window)
+        else:
+            per_repo = None
+            count = count_merged_prs_for_window(client, owner, window)
+        rows.append(
+            MonthlyMergedCount(
+                month=window.label,
+                window_start=window.start,
+                window_end=window.end,
+                merged_prs=count,
+                per_repo=per_repo,
+            )
+        )
+
+    rate_limit_events = tuple(
+        {
+            "url": event.url,
+            "status_code": event.status_code,
+            "slept_seconds": event.slept_seconds,
+            "reset_at": event.reset_at,
+        }
+        for event in client.rate_limit_events
+    )
+    return MergedPrReport(
+        owner=owner,
+        range_start=range_start,
+        range_end=range_end,
+        rows=tuple(rows),
+        rate_limit_events=rate_limit_events,
+    )
+
+
+def _render_per_repo_block(report: MergedPrReport) -> list[str]:
+    lines: list[str] = ["Per-repo merged PRs (verbose)"]
+    for row in report.rows:
+        if row.per_repo is None:
+            continue
+        lines.append(f"{row.month}  ({row.merged_prs:,} total)")
+        if not row.per_repo:
+            lines.append("  (no merged PRs)")
+            continue
+        ranked = sorted(row.per_repo.items(), key=lambda item: (-item[1], item[0]))
+        repo_width = max(len(repo) for repo, _ in ranked)
+        for repo, count in ranked:
+            lines.append(f"  {repo:<{repo_width}}  {count:>6,}")
+    lines.append("")
+    return lines
+
+
+def render_table(report: MergedPrReport) -> str:
+    header = (
+        f"Org: {report.owner}  |  Window: "
+        f"{report.range_start.isoformat()} .. {report.range_end.isoformat()}  |  "
+        "Visibility: token-scoped (private repos included if the token can see them)"
+    )
+    lines: list[str] = []
+    if any(row.per_repo is not None for row in report.rows):
+        lines.extend(_render_per_repo_block(report))
+    lines.append(header)
+    lines.append("")
+    lines.append(f"{'month':<10}{'merged_prs':>12}")
+    for row in report.rows:
+        lines.append(f"{row.month:<10}{row.merged_prs:>12,}")
+    lines.append(f"{'TOTAL':<10}{report.total:>12,}")
+    if report.rate_limit_events:
+        lines.append("")
+        lines.append(f"rate_limit_events: {len(report.rate_limit_events)}")
+    return "\n".join(lines)
+
+
+def render_json(report: MergedPrReport) -> str:
+    rows_payload: list[dict[str, Any]] = []
+    for row in report.rows:
+        item: dict[str, Any] = {
+            "month": row.month,
+            "window_start": row.window_start.isoformat(),
+            "window_end": row.window_end.isoformat(),
+            "merged_prs": row.merged_prs,
+        }
+        if row.per_repo is not None:
+            item["per_repo"] = dict(sorted(row.per_repo.items(), key=lambda kv: (-kv[1], kv[0])))
+        rows_payload.append(item)
+    payload = {
+        "owner": report.owner,
+        "from": report.range_start.isoformat(),
+        "to": report.range_end.isoformat(),
+        "rows": rows_payload,
+        "total": report.total,
+        "rate_limit_events": list(report.rate_limit_events),
+    }
+    return json.dumps(payload, indent=2)
+
+
+def render_csv(report: MergedPrReport) -> str:
+    buffer = io.StringIO()
+    writer = csv.writer(buffer)
+    if any(row.per_repo is not None for row in report.rows):
+        writer.writerow(["month", "repo", "merged_prs"])
+        for row in report.rows:
+            if row.per_repo is None:
+                continue
+            for repo, count in sorted(row.per_repo.items(), key=lambda kv: (-kv[1], kv[0])):
+                writer.writerow([row.month, repo, count])
+            writer.writerow([row.month, "(month total)", row.merged_prs])
+        writer.writerow(["TOTAL", "", report.total])
+    else:
+        writer.writerow(["month", "window_start", "window_end", "merged_prs"])
+        for row in report.rows:
+            writer.writerow([row.month, row.window_start.isoformat(), row.window_end.isoformat(), row.merged_prs])
+        writer.writerow(["TOTAL", "", "", report.total])
+    return buffer.getvalue().rstrip("\n")
+
+
+def render_report(report: MergedPrReport, output_format: str) -> str:
+    if output_format == "json":
+        return render_json(report)
+    if output_format == "csv":
+        return render_csv(report)
+    return render_table(report)
+
+
+def main() -> None:
+    parser = build_argument_parser()
+    args = parser.parse_args()
+
+    if not getattr(args, "owner", None):
+        args.owner = os.getenv(ENV_OWNER_KEY)
+    if not args.owner:
+        parser.error(f"GitHub owner missing. Provide --owner or set {ENV_OWNER_KEY}.")
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.debug else logging.INFO,
+        format="%(asctime)s - %(levelname)s - %(message)s",
+        datefmt="%H:%M:%S",
+    )
+
+    try:
+        token = load_token(args.token_env)
+        client = GitHubClient(token, auth_source=f"env:{args.token_env}")
+        report = collect_report(client, args.owner, args.from_date, args.to_date, verbose=args.verbose)
+        print(render_report(report, args.format))
+    except Exception as exc:  # pylint: disable=broad-except
+        logging.getLogger(__name__).error("%s", exc)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/git_metrics/org_merged_prs_per_month.py
+++ b/git_metrics/org_merged_prs_per_month.py
@@ -122,7 +122,10 @@ def build_argument_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--owner",
         default=argparse.SUPPRESS,
-        help=f"GitHub organization or user. Defaults to ${ENV_OWNER_KEY}.",
+        help=(
+            "GitHub organization login. Searches are org-scoped (org:<owner>); "
+            f"user accounts are not supported. Defaults to ${ENV_OWNER_KEY}."
+        ),
     )
     parser.add_argument(
         "--token-env",
@@ -332,11 +335,18 @@ def collect_report(
     *,
     verbose: bool = False,
     loc: bool = False,
+    today: date | None = None,
     sleep_fn: Any = time.sleep,
     pause_seconds: float = INTER_REQUEST_PAUSE_SECONDS,
 ) -> MergedPrReport:
     if range_end < range_start:
         raise ValueError("--to must be on or after --from")
+    today_value = today if today is not None else datetime.now().date()
+    if range_end > today_value:
+        raise ValueError(
+            f"--to ({range_end.isoformat()}) is in the future (today is {today_value.isoformat()}); "
+            "future months would emit misleading zero-data rows"
+        )
 
     rows: list[MonthlyMergedCount] = []
     windows = month_windows(range_start, range_end)
@@ -466,7 +476,17 @@ def render_csv(report: MergedPrReport) -> str:
     buffer = io.StringIO()
     writer = csv.writer(buffer)
     has_per_repo = any(row.per_repo is not None for row in report.rows)
-    if has_per_repo:
+    if has_per_repo and report.has_loc:
+        writer.writerow(["month", "repo", "merged_prs", "additions", "deletions"])
+        for row in report.rows:
+            if row.per_repo is None:
+                continue
+            for repo, count in sorted(row.per_repo.items(), key=lambda kv: (-kv[1], kv[0])):
+                # Per-repo LOC is not collected in this revision; leave additions/deletions blank.
+                writer.writerow([row.month, repo, count, "", ""])
+            writer.writerow([row.month, "(month total)", row.merged_prs, row.additions or 0, row.deletions or 0])
+        writer.writerow(["TOTAL", "", report.total, report.total_additions, report.total_deletions])
+    elif has_per_repo:
         writer.writerow(["month", "repo", "merged_prs"])
         for row in report.rows:
             if row.per_repo is None:

--- a/git_metrics/org_merged_prs_per_month.py
+++ b/git_metrics/org_merged_prs_per_month.py
@@ -26,13 +26,21 @@ import os
 import sys
 import time
 from dataclasses import dataclass
-from datetime import date, datetime, timedelta
+from datetime import date, datetime, timedelta, timezone
+from pathlib import Path
 from typing import Any
 
 from dotenv import load_dotenv
 
-from git_metrics.ci_maturity_report import DEFAULT_TOKEN_ENV, GitHubClient, load_token
-from git_metrics.throughput_collect import MonthWindow, month_windows
+try:
+    from git_metrics.ci_maturity_report import DEFAULT_TOKEN_ENV, GitHubClient, load_token
+    from git_metrics.throughput_collect import MonthWindow, month_windows
+except ModuleNotFoundError as exc:
+    if exc.name != "git_metrics":
+        raise
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+    from git_metrics.ci_maturity_report import DEFAULT_TOKEN_ENV, GitHubClient, load_token
+    from git_metrics.throughput_collect import MonthWindow, month_windows
 
 
 load_dotenv()
@@ -58,6 +66,10 @@ query($q: String!, $cursor: String) {
   }
 }
 """
+
+
+class HelpFormatter(argparse.ArgumentDefaultsHelpFormatter, argparse.RawDescriptionHelpFormatter):
+    """Show defaults while preserving multiline examples."""
 
 
 @dataclass(frozen=True)
@@ -103,7 +115,16 @@ def parse_iso_date(value: str) -> date:
 def build_argument_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         description="Count merged PRs per month across an entire GitHub organization.",
-        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+        formatter_class=HelpFormatter,
+        epilog=(
+            "examples:\n"
+            "  python3 -m git_metrics.org_merged_prs_per_month "
+            "--owner onfleet --from 2025-01-01 --to 2026-04-30\n"
+            "  python3 -m git_metrics.org_merged_prs_per_month "
+            "--owner onfleet --from 2025-01-01 --to 2026-04-30 --verbose --loc\n\n"
+            "module form matters: put git_metrics.org_merged_prs_per_month immediately after -m, "
+            "then pass CLI flags. Use -v or --verbose, not --v."
+        ),
     )
     parser.add_argument(
         "--from",
@@ -215,7 +236,7 @@ def _per_repo_counts_for_range(
         return counts, 0
 
     page = 1
-    max_pages = (SEARCH_RESULT_CAP // SEARCH_PAGE_SIZE) + 1
+    max_pages = SEARCH_RESULT_CAP // SEARCH_PAGE_SIZE
     while page <= max_pages:
         payload = client.get_json(
             "/search/issues",
@@ -341,7 +362,7 @@ def collect_report(
 ) -> MergedPrReport:
     if range_end < range_start:
         raise ValueError("--to must be on or after --from")
-    today_value = today if today is not None else datetime.now().date()
+    today_value = today if today is not None else datetime.now(timezone.utc).date()
     if range_end > today_value:
         raise ValueError(
             f"--to ({range_end.isoformat()}) is in the future (today is {today_value.isoformat()}); "
@@ -363,6 +384,7 @@ def collect_report(
         if loc:
             if pause_seconds > 0:
                 sleep_fn(pause_seconds)
+            # REST total_count is canonical for merged_prs; GraphQL issueCount is dropped.
             additions, deletions, _loc_total = loc_for_window(client, owner, window)
         rows.append(
             MonthlyMergedCount(

--- a/git_metrics/org_merged_prs_per_month.py
+++ b/git_metrics/org_merged_prs_per_month.py
@@ -41,6 +41,23 @@ ENV_OWNER_KEY = "GITHUB_METRIC_OWNER_OR_ORGANIZATION"
 INTER_REQUEST_PAUSE_SECONDS = 0.25
 SEARCH_RESULT_CAP = 1000
 SEARCH_PAGE_SIZE = 100
+GRAPHQL_URL = "https://api.github.com/graphql"
+GRAPHQL_PAGE_SIZE = 100
+
+GRAPHQL_LOC_QUERY = """
+query($q: String!, $cursor: String) {
+  search(type: ISSUE, query: $q, first: 100, after: $cursor) {
+    issueCount
+    pageInfo { hasNextPage endCursor }
+    nodes {
+      ... on PullRequest {
+        additions
+        deletions
+      }
+    }
+  }
+}
+"""
 
 
 @dataclass(frozen=True)
@@ -50,6 +67,8 @@ class MonthlyMergedCount:
     window_end: date
     merged_prs: int
     per_repo: dict[str, int] | None = None
+    additions: int | None = None
+    deletions: int | None = None
 
 
 @dataclass(frozen=True)
@@ -63,6 +82,18 @@ class MergedPrReport:
     @property
     def total(self) -> int:
         return sum(row.merged_prs for row in self.rows)
+
+    @property
+    def has_loc(self) -> bool:
+        return any(row.additions is not None or row.deletions is not None for row in self.rows)
+
+    @property
+    def total_additions(self) -> int:
+        return sum(row.additions or 0 for row in self.rows)
+
+    @property
+    def total_deletions(self) -> int:
+        return sum(row.deletions or 0 for row in self.rows)
 
 
 def parse_iso_date(value: str) -> date:
@@ -109,6 +140,12 @@ def build_argument_parser() -> argparse.ArgumentParser:
         "--verbose",
         action="store_true",
         help="Also report per-repo merged PR counts per month. Costs extra API calls (paginates search results).",
+    )
+    parser.add_argument(
+        "-l",
+        "--loc",
+        action="store_true",
+        help="Also report total additions and deletions per month. Uses GraphQL search to collect per-PR LOC data.",
     )
     parser.add_argument("--debug", action="store_true", help="Enable debug logging.")
     return parser
@@ -194,6 +231,99 @@ def _per_repo_counts_for_range(
     return counts, total
 
 
+def _graphql(client: GitHubClient, query: str, variables: dict[str, Any]) -> dict[str, Any]:
+    """POST to GraphQL, reusing the REST client's session and rate-limit backoff.
+
+    GitHub returns GraphQL rate-limit errors as HTTP 200 with an ``errors`` field,
+    so we have to detect them in the JSON payload too — not just via status codes.
+    """
+
+    for attempt in range(1, client.max_retries + 1):
+        response = client.session.post(
+            GRAPHQL_URL,
+            json={"query": query, "variables": variables},
+            timeout=60,
+        )
+        if client._should_wait_for_rate_limit(response):
+            if attempt == client.max_retries:
+                response.raise_for_status()
+            client._wait_for_rate_limit(response, GRAPHQL_URL)
+            continue
+
+        response.raise_for_status()
+        payload = response.json()
+        if "errors" in payload:
+            messages = "; ".join(error.get("message", "unknown error") for error in payload["errors"])
+            if attempt < client.max_retries and "rate limit" in messages.lower():
+                client._wait_for_rate_limit(response, GRAPHQL_URL)
+                continue
+            raise RuntimeError(f"GraphQL error: {messages}")
+        return payload["data"]
+
+    raise RuntimeError(f"GraphQL request failed after {client.max_retries} attempts")
+
+
+def loc_for_window(
+    client: GitHubClient,
+    owner: str,
+    window: MonthWindow,
+) -> tuple[int, int, int]:
+    """Return ``(additions, deletions, total_count)`` for merged PRs in ``window``.
+
+    Uses GraphQL search so that additions/deletions arrive in the same page as the
+    PR identity. Halves the window recursively if the result set exceeds the
+    1000-result Search cap.
+    """
+
+    return _loc_for_range(client, owner, window.start, window.end)
+
+
+def _loc_for_range(
+    client: GitHubClient,
+    owner: str,
+    range_start: date,
+    range_end: date,
+) -> tuple[int, int, int]:
+    query_text = _search_query(owner, range_start, range_end)
+    cursor: str | None = None
+    additions = 0
+    deletions = 0
+    total = 0
+    first_page = True
+
+    while True:
+        data = _graphql(client, GRAPHQL_LOC_QUERY, {"q": query_text, "cursor": cursor})
+        search = data["search"]
+        if first_page:
+            total = int(search.get("issueCount") or 0)
+            if total > SEARCH_RESULT_CAP:
+                if range_start >= range_end:
+                    raise RuntimeError(
+                        f"GitHub search returned more than {SEARCH_RESULT_CAP} merged PRs for "
+                        f"org:{owner} on {range_start.isoformat()}; cannot collect LOC accurately"
+                    )
+                midpoint = range_start + timedelta(days=(range_end - range_start).days // 2)
+                left_add, left_del, left_total = _loc_for_range(client, owner, range_start, midpoint)
+                right_add, right_del, right_total = _loc_for_range(
+                    client, owner, midpoint + timedelta(days=1), range_end
+                )
+                return left_add + right_add, left_del + right_del, left_total + right_total
+            first_page = False
+
+        for node in search.get("nodes") or []:
+            if not node:
+                continue
+            additions += int(node.get("additions") or 0)
+            deletions += int(node.get("deletions") or 0)
+
+        page_info = search.get("pageInfo") or {}
+        if not page_info.get("hasNextPage"):
+            break
+        cursor = page_info.get("endCursor")
+
+    return additions, deletions, total
+
+
 def collect_report(
     client: GitHubClient,
     owner: str,
@@ -201,6 +331,7 @@ def collect_report(
     range_end: date,
     *,
     verbose: bool = False,
+    loc: bool = False,
     sleep_fn: Any = time.sleep,
     pause_seconds: float = INTER_REQUEST_PAUSE_SECONDS,
 ) -> MergedPrReport:
@@ -217,6 +348,12 @@ def collect_report(
         else:
             per_repo = None
             count = count_merged_prs_for_window(client, owner, window)
+        additions: int | None = None
+        deletions: int | None = None
+        if loc:
+            if pause_seconds > 0:
+                sleep_fn(pause_seconds)
+            additions, deletions, _loc_total = loc_for_window(client, owner, window)
         rows.append(
             MonthlyMergedCount(
                 month=window.label,
@@ -224,6 +361,8 @@ def collect_report(
                 window_end=window.end,
                 merged_prs=count,
                 per_repo=per_repo,
+                additions=additions,
+                deletions=deletions,
             )
         )
 
@@ -273,10 +412,20 @@ def render_table(report: MergedPrReport) -> str:
         lines.extend(_render_per_repo_block(report))
     lines.append(header)
     lines.append("")
-    lines.append(f"{'month':<10}{'merged_prs':>12}")
-    for row in report.rows:
-        lines.append(f"{row.month:<10}{row.merged_prs:>12,}")
-    lines.append(f"{'TOTAL':<10}{report.total:>12,}")
+    if report.has_loc:
+        lines.append(f"{'month':<10}{'merged_prs':>12}{'additions':>14}{'deletions':>14}")
+        for row in report.rows:
+            lines.append(
+                f"{row.month:<10}{row.merged_prs:>12,}" f"{(row.additions or 0):>14,}" f"{(row.deletions or 0):>14,}"
+            )
+        lines.append(
+            f"{'TOTAL':<10}{report.total:>12,}" f"{report.total_additions:>14,}" f"{report.total_deletions:>14,}"
+        )
+    else:
+        lines.append(f"{'month':<10}{'merged_prs':>12}")
+        for row in report.rows:
+            lines.append(f"{row.month:<10}{row.merged_prs:>12,}")
+        lines.append(f"{'TOTAL':<10}{report.total:>12,}")
     if report.rate_limit_events:
         lines.append("")
         lines.append(f"rate_limit_events: {len(report.rate_limit_events)}")
@@ -292,10 +441,14 @@ def render_json(report: MergedPrReport) -> str:
             "window_end": row.window_end.isoformat(),
             "merged_prs": row.merged_prs,
         }
+        if row.additions is not None:
+            item["additions"] = row.additions
+        if row.deletions is not None:
+            item["deletions"] = row.deletions
         if row.per_repo is not None:
             item["per_repo"] = dict(sorted(row.per_repo.items(), key=lambda kv: (-kv[1], kv[0])))
         rows_payload.append(item)
-    payload = {
+    payload: dict[str, Any] = {
         "owner": report.owner,
         "from": report.range_start.isoformat(),
         "to": report.range_end.isoformat(),
@@ -303,13 +456,17 @@ def render_json(report: MergedPrReport) -> str:
         "total": report.total,
         "rate_limit_events": list(report.rate_limit_events),
     }
+    if report.has_loc:
+        payload["total_additions"] = report.total_additions
+        payload["total_deletions"] = report.total_deletions
     return json.dumps(payload, indent=2)
 
 
 def render_csv(report: MergedPrReport) -> str:
     buffer = io.StringIO()
     writer = csv.writer(buffer)
-    if any(row.per_repo is not None for row in report.rows):
+    has_per_repo = any(row.per_repo is not None for row in report.rows)
+    if has_per_repo:
         writer.writerow(["month", "repo", "merged_prs"])
         for row in report.rows:
             if row.per_repo is None:
@@ -318,6 +475,20 @@ def render_csv(report: MergedPrReport) -> str:
                 writer.writerow([row.month, repo, count])
             writer.writerow([row.month, "(month total)", row.merged_prs])
         writer.writerow(["TOTAL", "", report.total])
+    elif report.has_loc:
+        writer.writerow(["month", "window_start", "window_end", "merged_prs", "additions", "deletions"])
+        for row in report.rows:
+            writer.writerow(
+                [
+                    row.month,
+                    row.window_start.isoformat(),
+                    row.window_end.isoformat(),
+                    row.merged_prs,
+                    row.additions or 0,
+                    row.deletions or 0,
+                ]
+            )
+        writer.writerow(["TOTAL", "", "", report.total, report.total_additions, report.total_deletions])
     else:
         writer.writerow(["month", "window_start", "window_end", "merged_prs"])
         for row in report.rows:
@@ -352,7 +523,7 @@ def main() -> None:
     try:
         token = load_token(args.token_env)
         client = GitHubClient(token, auth_source=f"env:{args.token_env}")
-        report = collect_report(client, args.owner, args.from_date, args.to_date, verbose=args.verbose)
+        report = collect_report(client, args.owner, args.from_date, args.to_date, verbose=args.verbose, loc=args.loc)
         print(render_report(report, args.format))
     except Exception as exc:  # pylint: disable=broad-except
         logging.getLogger(__name__).error("%s", exc)

--- a/tests/unit/git_metrics/test_org_merged_prs_per_month.py
+++ b/tests/unit/git_metrics/test_org_merged_prs_per_month.py
@@ -12,6 +12,7 @@ from git_metrics.org_merged_prs_per_month import (
     build_argument_parser,
     collect_report,
     count_merged_prs_for_window,
+    loc_for_window,
     per_repo_counts_for_window,
     render_csv,
     render_json,
@@ -42,10 +43,17 @@ class _RecordingSession:
     def __init__(self, responses: list[_StubResponse]):
         self._responses = list(responses)
         self.calls: list[tuple[str, dict[str, Any] | None]] = []
+        self.post_calls: list[tuple[str, dict[str, Any] | None]] = []
         self.headers: dict[str, str] = {}
 
     def get(self, url: str, *, params: dict[str, Any] | None = None, timeout: float = 0) -> _StubResponse:
         self.calls.append((url, dict(params) if params is not None else None))
+        if not self._responses:
+            raise AssertionError("no scripted responses left")
+        return self._responses.pop(0)
+
+    def post(self, url: str, *, json: dict[str, Any] | None = None, timeout: float = 0) -> _StubResponse:
+        self.post_calls.append((url, dict(json) if json is not None else None))
         if not self._responses:
             raise AssertionError("no scripted responses left")
         return self._responses.pop(0)
@@ -366,6 +374,209 @@ def test_argument_parser_accepts_short_v_flag() -> None:
     assert args.verbose is True
     args_default = parser.parse_args(["--from", "2025-01-01", "--to", "2025-12-31"])
     assert args_default.verbose is False
+
+
+def _graphql_response(*, total: int, nodes: list[dict[str, int]], next_cursor: str | None = None) -> _StubResponse:
+    return _StubResponse(
+        200,
+        {
+            "data": {
+                "search": {
+                    "issueCount": total,
+                    "pageInfo": {
+                        "hasNextPage": bool(next_cursor),
+                        "endCursor": next_cursor,
+                    },
+                    "nodes": nodes,
+                }
+            }
+        },
+    )
+
+
+def test_loc_for_window_sums_additions_and_deletions_across_pages() -> None:
+    responses = [
+        _graphql_response(
+            total=3,
+            nodes=[
+                {"additions": 100, "deletions": 30},
+                {"additions": 50, "deletions": 20},
+            ],
+            next_cursor="abc",
+        ),
+        _graphql_response(
+            total=3,
+            nodes=[
+                {"additions": 7, "deletions": 1},
+            ],
+        ),
+    ]
+    client, session, _sleeps = _make_client(responses)
+    window = MonthWindow(label="2025-04", start=date(2025, 4, 1), end=date(2025, 4, 30))
+
+    additions, deletions, total = loc_for_window(client, "onfleet", window)
+
+    assert (additions, deletions, total) == (157, 51, 3)
+    # GraphQL POSTs only — no REST GETs from this path.
+    assert len(session.post_calls) == 2
+    assert len(session.calls) == 0
+    first_payload = session.post_calls[0][1]
+    assert first_payload is not None
+    assert "query" in first_payload and "search" in first_payload["query"]
+    assert first_payload["variables"]["q"] == "org:onfleet is:pr is:merged merged:2025-04-01..2025-04-30"
+    assert first_payload["variables"]["cursor"] is None
+    # Second page passes the cursor returned by the first.
+    assert session.post_calls[1][1]["variables"]["cursor"] == "abc"
+
+
+def test_loc_for_window_halves_window_when_total_exceeds_search_cap() -> None:
+    responses = [
+        _graphql_response(total=1500, nodes=[]),  # head -> too big -> split
+        _graphql_response(  # left half
+            total=700,
+            nodes=[{"additions": 200, "deletions": 80}],
+        ),
+        _graphql_response(  # right half
+            total=800,
+            nodes=[{"additions": 300, "deletions": 50}],
+        ),
+    ]
+    client, _session, _sleeps = _make_client(responses)
+    window = MonthWindow(label="2025-04", start=date(2025, 4, 1), end=date(2025, 4, 30))
+
+    additions, deletions, total = loc_for_window(client, "onfleet", window)
+
+    assert additions == 500
+    assert deletions == 130
+    assert total == 1500
+
+
+def test_collect_report_in_loc_mode_attaches_additions_and_deletions() -> None:
+    responses = [
+        # Apr: count head, then graphql
+        _StubResponse(200, {"total_count": 2}),
+        _graphql_response(total=2, nodes=[{"additions": 100, "deletions": 30}, {"additions": 50, "deletions": 20}]),
+        # May: count head, then graphql
+        _StubResponse(200, {"total_count": 1}),
+        _graphql_response(total=1, nodes=[{"additions": 9, "deletions": 4}]),
+    ]
+    client, _session, _sleeps = _make_client(responses)
+
+    report = collect_report(
+        client,
+        "onfleet",
+        date(2025, 4, 1),
+        date(2025, 5, 31),
+        loc=True,
+        sleep_fn=lambda _s: None,
+        pause_seconds=0,
+    )
+
+    assert [row.merged_prs for row in report.rows] == [2, 1]
+    assert [row.additions for row in report.rows] == [150, 9]
+    assert [row.deletions for row in report.rows] == [50, 4]
+    assert report.total == 3
+    assert report.total_additions == 159
+    assert report.total_deletions == 54
+    assert report.has_loc is True
+
+
+def test_render_table_in_loc_mode_includes_additions_and_deletions_columns() -> None:
+    responses = [
+        _StubResponse(200, {"total_count": 2}),
+        _graphql_response(total=2, nodes=[{"additions": 100, "deletions": 30}, {"additions": 50, "deletions": 20}]),
+    ]
+    client, _session, _sleeps = _make_client(responses)
+    report = collect_report(
+        client,
+        "onfleet",
+        date(2025, 4, 1),
+        date(2025, 4, 30),
+        loc=True,
+        sleep_fn=lambda _s: None,
+        pause_seconds=0,
+    )
+    rendered = render_table(report)
+    header_line = [line for line in rendered.splitlines() if "merged_prs" in line][0]
+    assert "additions" in header_line
+    assert "deletions" in header_line
+    apr_row = [line for line in rendered.splitlines() if line.startswith("2025-04")][0]
+    cells = apr_row.split()
+    assert cells[0] == "2025-04"
+    assert cells[1] == "2"
+    assert cells[2] == "150"
+    assert cells[3] == "50"
+    total_row = [line for line in rendered.splitlines() if line.startswith("TOTAL")][0]
+    assert total_row.split() == ["TOTAL", "2", "150", "50"]
+
+
+def test_render_json_in_loc_mode_includes_additions_deletions_and_totals() -> None:
+    responses = [
+        _StubResponse(200, {"total_count": 2}),
+        _graphql_response(total=2, nodes=[{"additions": 100, "deletions": 30}, {"additions": 50, "deletions": 20}]),
+    ]
+    client, _session, _sleeps = _make_client(responses)
+    report = collect_report(
+        client,
+        "onfleet",
+        date(2025, 4, 1),
+        date(2025, 4, 30),
+        loc=True,
+        sleep_fn=lambda _s: None,
+        pause_seconds=0,
+    )
+    payload = json.loads(render_json(report))
+    assert payload["rows"][0]["additions"] == 150
+    assert payload["rows"][0]["deletions"] == 50
+    assert payload["total_additions"] == 150
+    assert payload["total_deletions"] == 50
+
+
+def test_render_csv_in_loc_mode_emits_extra_columns() -> None:
+    responses = [
+        _StubResponse(200, {"total_count": 2}),
+        _graphql_response(total=2, nodes=[{"additions": 100, "deletions": 30}, {"additions": 50, "deletions": 20}]),
+    ]
+    client, _session, _sleeps = _make_client(responses)
+    report = collect_report(
+        client,
+        "onfleet",
+        date(2025, 4, 1),
+        date(2025, 4, 30),
+        loc=True,
+        sleep_fn=lambda _s: None,
+        pause_seconds=0,
+    )
+    rendered = render_csv(report)
+    lines = rendered.splitlines()
+    assert lines[0] == "month,window_start,window_end,merged_prs,additions,deletions"
+    assert lines[1] == "2025-04,2025-04-01,2025-04-30,2,150,50"
+    assert lines[-1] == "TOTAL,,,2,150,50"
+
+
+def test_loc_for_window_retries_when_graphql_returns_200_with_rate_limit_error() -> None:
+    rate_limited = _StubResponse(
+        200,
+        {"errors": [{"message": "API rate limit exceeded for user"}]},
+        headers={"Retry-After": "1"},
+    )
+    success = _graphql_response(total=1, nodes=[{"additions": 5, "deletions": 2}])
+    client, _session, sleeps = _make_client([rate_limited, success])
+    window = MonthWindow(label="2025-04", start=date(2025, 4, 1), end=date(2025, 4, 30))
+
+    additions, deletions, total = loc_for_window(client, "onfleet", window)
+
+    assert (additions, deletions, total) == (5, 2, 1)
+    assert sleeps == [1.0]
+    assert len(client.rate_limit_events) == 1
+
+
+def test_argument_parser_accepts_short_l_flag() -> None:
+    parser = build_argument_parser()
+    args = parser.parse_args(["--from", "2025-01-01", "--to", "2025-12-31", "-l"])
+    assert args.loc is True
+    args_default = parser.parse_args(["--from", "2025-01-01", "--to", "2025-12-31"])
+    assert args_default.loc is False
 
 
 def test_month_windows_sanity_check_for_year_boundaries() -> None:

--- a/tests/unit/git_metrics/test_org_merged_prs_per_month.py
+++ b/tests/unit/git_metrics/test_org_merged_prs_per_month.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
 import json
+import subprocess
+import sys
 from datetime import date
+from pathlib import Path
 from typing import Any
 
 import pytest
@@ -257,6 +260,26 @@ def test_per_repo_counts_paginates_and_aggregates_by_repo() -> None:
     assert session.calls[1][1]["per_page"] == 100
     assert session.calls[1][1]["page"] == 1
     assert session.calls[2][1]["page"] == 2
+
+
+def test_per_repo_counts_stops_at_page_10_when_total_equals_search_cap() -> None:
+    # GitHub Search caps at page 10 (1000 results); page 11 returns 422.
+    # When total == 1000 exactly, the loop must terminate after page 10
+    # without attempting page 11.
+    full_page = _items_payload(["api"] * 100, total=1000)
+    responses = [_StubResponse(200, {"total_count": 1000, "items": []})]  # head
+    responses.extend(_StubResponse(200, full_page) for _ in range(10))
+    client, session, _sleeps = _make_client(responses)
+    window = MonthWindow(label="2025-05", start=date(2025, 5, 1), end=date(2025, 5, 31))
+
+    counts, total = per_repo_counts_for_window(client, "onfleet", window)
+
+    assert total == 1000
+    assert counts == {"api": 1000}
+    # 1 head probe + 10 paginated calls = 11 total. No page 11 requested.
+    assert len(session.calls) == 11
+    pages_requested = [params.get("page") for _url, params in session.calls if params and params.get("page")]
+    assert pages_requested == list(range(1, 11))
 
 
 def test_per_repo_counts_halves_window_when_total_exceeds_search_cap() -> None:
@@ -627,6 +650,22 @@ def test_argument_parser_accepts_short_l_flag() -> None:
     assert args.loc is True
     args_default = parser.parse_args(["--from", "2025-01-01", "--to", "2025-12-31"])
     assert args_default.loc is False
+
+
+def test_script_path_help_explains_module_invocation_and_verbose_flag() -> None:
+    repo_root = Path(__file__).resolve().parents[3]
+
+    result = subprocess.run(
+        [sys.executable, "git_metrics/org_merged_prs_per_month.py", "--help"],
+        cwd=repo_root,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert "python3 -m git_metrics.org_merged_prs_per_month" in result.stdout
+    assert "Use -v or --verbose, not --v." in result.stdout
 
 
 def test_month_windows_sanity_check_for_year_boundaries() -> None:

--- a/tests/unit/git_metrics/test_org_merged_prs_per_month.py
+++ b/tests/unit/git_metrics/test_org_merged_prs_per_month.py
@@ -1,0 +1,378 @@
+from __future__ import annotations
+
+import json
+from datetime import date
+from typing import Any
+
+import pytest
+import requests
+
+from git_metrics.ci_maturity_report import GitHubClient
+from git_metrics.org_merged_prs_per_month import (
+    build_argument_parser,
+    collect_report,
+    count_merged_prs_for_window,
+    per_repo_counts_for_window,
+    render_csv,
+    render_json,
+    render_table,
+)
+from git_metrics.throughput_collect import MonthWindow, month_windows
+
+
+class _StubResponse:
+    def __init__(self, status_code: int, payload: dict[str, Any] | None = None, headers: dict[str, str] | None = None):
+        self.status_code = status_code
+        self.reason = "OK" if status_code == 200 else "ERR"
+        self._payload = payload or {}
+        self.headers = headers or {}
+        self.text = json.dumps(self._payload)
+
+    def json(self) -> dict[str, Any]:
+        return self._payload
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            raise requests.HTTPError(f"{self.status_code} error", response=self)
+
+
+class _RecordingSession:
+    """Stand-in for requests.Session that returns scripted responses."""
+
+    def __init__(self, responses: list[_StubResponse]):
+        self._responses = list(responses)
+        self.calls: list[tuple[str, dict[str, Any] | None]] = []
+        self.headers: dict[str, str] = {}
+
+    def get(self, url: str, *, params: dict[str, Any] | None = None, timeout: float = 0) -> _StubResponse:
+        self.calls.append((url, dict(params) if params is not None else None))
+        if not self._responses:
+            raise AssertionError("no scripted responses left")
+        return self._responses.pop(0)
+
+
+def _make_client(responses: list[_StubResponse]) -> tuple[GitHubClient, _RecordingSession, list[float]]:
+    sleeps: list[float] = []
+    client = GitHubClient("token", sleep_fn=sleeps.append)
+    session = _RecordingSession(responses)
+    client.session = session  # type: ignore[assignment]
+    return client, session, sleeps
+
+
+def test_count_merged_prs_for_window_builds_search_query_and_extracts_total_count() -> None:
+    client, session, _sleeps = _make_client([_StubResponse(200, {"total_count": 142, "incomplete_results": False})])
+    window = MonthWindow(label="2025-05", start=date(2025, 5, 1), end=date(2025, 5, 31))
+
+    count = count_merged_prs_for_window(client, "onfleet", window)
+
+    assert count == 142
+    assert len(session.calls) == 1
+    url, params = session.calls[0]
+    assert url == "https://api.github.com/search/issues"
+    assert params == {
+        "q": "org:onfleet is:pr is:merged merged:2025-05-01..2025-05-31",
+        "per_page": 1,
+    }
+
+
+def test_count_merged_prs_handles_missing_total_count_as_zero() -> None:
+    client, _session, _sleeps = _make_client([_StubResponse(200, {"incomplete_results": False})])
+    window = MonthWindow(label="2025-05", start=date(2025, 5, 1), end=date(2025, 5, 31))
+
+    assert count_merged_prs_for_window(client, "onfleet", window) == 0
+
+
+def test_collect_report_iterates_month_windows_and_paces_requests() -> None:
+    responses = [
+        _StubResponse(200, {"total_count": 10}),
+        _StubResponse(200, {"total_count": 22}),
+        _StubResponse(200, {"total_count": 5}),
+    ]
+    client, session, sleeps = _make_client(responses)
+
+    report = collect_report(
+        client,
+        "onfleet",
+        date(2025, 3, 15),
+        date(2025, 5, 8),
+        sleep_fn=sleeps.append,
+        pause_seconds=0.1,
+    )
+
+    # 3 windows: partial March, full April, partial May (clamped by month_windows)
+    assert [row.month for row in report.rows] == ["2025-03", "2025-04", "2025-05"]
+    assert [row.merged_prs for row in report.rows] == [10, 22, 5]
+    assert report.total == 37
+    assert report.rows[0].window_start == date(2025, 3, 15)
+    assert report.rows[-1].window_end == date(2025, 5, 8)
+    # Pacing pauses fire between calls only (N-1 pauses).
+    assert sleeps == [0.1, 0.1]
+    # Each call hits search/issues with the right per-window query string.
+    assert all(call[0] == "https://api.github.com/search/issues" for call in session.calls)
+    assert session.calls[0][1] == {
+        "q": "org:onfleet is:pr is:merged merged:2025-03-15..2025-03-31",
+        "per_page": 1,
+    }
+    assert session.calls[1][1] == {
+        "q": "org:onfleet is:pr is:merged merged:2025-04-01..2025-04-30",
+        "per_page": 1,
+    }
+    assert session.calls[2][1] == {
+        "q": "org:onfleet is:pr is:merged merged:2025-05-01..2025-05-08",
+        "per_page": 1,
+    }
+
+
+def test_collect_report_retries_after_secondary_rate_limit() -> None:
+    rate_limited = _StubResponse(
+        403,
+        {"message": "API rate limit exceeded"},
+        headers={"Retry-After": "1"},
+    )
+    rate_limited.text = "API rate limit exceeded"
+    responses = [rate_limited, _StubResponse(200, {"total_count": 7})]
+    client, _session, sleeps = _make_client(responses)
+    window = MonthWindow(label="2025-05", start=date(2025, 5, 1), end=date(2025, 5, 31))
+
+    count = count_merged_prs_for_window(client, "onfleet", window)
+
+    assert count == 7
+    assert sleeps == [1.0]
+    assert len(client.rate_limit_events) == 1
+    assert client.rate_limit_events[0].slept_seconds == 1.0
+
+
+def test_collect_report_rejects_inverted_range() -> None:
+    client, _session, _sleeps = _make_client([])
+    with pytest.raises(ValueError):
+        collect_report(client, "onfleet", date(2025, 6, 1), date(2025, 5, 1), sleep_fn=lambda _s: None)
+
+
+def _sample_report():
+    return collect_report(
+        *_make_collect_inputs(),
+        sleep_fn=lambda _s: None,
+        pause_seconds=0,
+    )
+
+
+def _make_collect_inputs():
+    responses = [
+        _StubResponse(200, {"total_count": 100}),
+        _StubResponse(200, {"total_count": 250}),
+    ]
+    client, _session, _sleeps = _make_client(responses)
+    return client, "onfleet", date(2025, 4, 1), date(2025, 5, 31)
+
+
+def test_render_table_shows_per_month_rows_and_total() -> None:
+    report = _sample_report()
+    rendered = render_table(report)
+    assert "Org: onfleet" in rendered
+    assert "Window: 2025-04-01 .. 2025-05-31" in rendered
+    lines = {line.split()[0]: line for line in rendered.splitlines() if line and line.split()}
+    assert lines["2025-04"].split() == ["2025-04", "100"]
+    assert lines["2025-05"].split() == ["2025-05", "250"]
+    assert lines["TOTAL"].split() == ["TOTAL", "350"]
+
+
+def test_render_json_serializes_full_payload() -> None:
+    report = _sample_report()
+    payload = json.loads(render_json(report))
+    assert payload["owner"] == "onfleet"
+    assert payload["from"] == "2025-04-01"
+    assert payload["to"] == "2025-05-31"
+    assert payload["total"] == 350
+    assert payload["rows"][0] == {
+        "month": "2025-04",
+        "window_start": "2025-04-01",
+        "window_end": "2025-04-30",
+        "merged_prs": 100,
+    }
+    assert payload["rate_limit_events"] == []
+
+
+def test_render_csv_emits_header_rows_and_total() -> None:
+    report = _sample_report()
+    rendered = render_csv(report)
+    assert rendered.splitlines()[0] == "month,window_start,window_end,merged_prs"
+    assert rendered.splitlines()[1] == "2025-04,2025-04-01,2025-04-30,100"
+    assert rendered.splitlines()[2] == "2025-05,2025-05-01,2025-05-31,250"
+    assert rendered.splitlines()[-1] == "TOTAL,,,350"
+
+
+def test_argument_parser_requires_from_and_to_and_defaults_format_to_table() -> None:
+    parser = build_argument_parser()
+    args = parser.parse_args(["--from", "2025-01-01", "--to", "2025-12-31"])
+    assert args.from_date == date(2025, 1, 1)
+    assert args.to_date == date(2025, 12, 31)
+    assert args.format == "table"
+    assert args.token_env == "GITHUB_TOKEN_READONLY_WEB"
+    assert not hasattr(args, "owner")  # SUPPRESS keeps it absent until env fallback
+
+
+def _items_payload(repos: list[str], total: int | None = None) -> dict[str, Any]:
+    items = [{"repository_url": f"https://api.github.com/repos/onfleet/{name}"} for name in repos]
+    return {"total_count": total if total is not None else len(repos), "items": items}
+
+
+def test_per_repo_counts_paginates_and_aggregates_by_repo() -> None:
+    page_one_repos = ["api"] * 60 + ["web"] * 40  # 100 items -> next page expected
+    page_two_repos = ["api"] * 5 + ["docs"] * 3  # < 100 items -> stop
+    responses = [
+        _StubResponse(200, {"total_count": 108, "items": []}),  # head probe (per_page=1)
+        _StubResponse(200, _items_payload(page_one_repos, total=108)),
+        _StubResponse(200, _items_payload(page_two_repos, total=108)),
+    ]
+    client, session, _sleeps = _make_client(responses)
+    window = MonthWindow(label="2025-05", start=date(2025, 5, 1), end=date(2025, 5, 31))
+
+    counts, total = per_repo_counts_for_window(client, "onfleet", window)
+
+    assert total == 108
+    assert counts == {"api": 65, "web": 40, "docs": 3}
+    # First call is the head probe with per_page=1; subsequent calls paginate at 100/page.
+    assert session.calls[0][1]["per_page"] == 1
+    assert session.calls[1][1]["per_page"] == 100
+    assert session.calls[1][1]["page"] == 1
+    assert session.calls[2][1]["page"] == 2
+
+
+def test_per_repo_counts_halves_window_when_total_exceeds_search_cap() -> None:
+    # >1000-result window forces a recursive split. Each half returns <100 items
+    # so pagination terminates cleanly and we can assert on the merged result.
+    responses = [
+        _StubResponse(200, {"total_count": 1500, "items": []}),  # head: too big -> split
+        _StubResponse(200, {"total_count": 700, "items": []}),  # left half head
+        _StubResponse(200, _items_payload(["api", "api", "web"], total=700)),
+        _StubResponse(200, {"total_count": 800, "items": []}),  # right half head
+        _StubResponse(200, _items_payload(["web", "docs"], total=800)),
+    ]
+    client, session, _sleeps = _make_client(responses)
+    window = MonthWindow(label="2025-05", start=date(2025, 5, 1), end=date(2025, 5, 31))
+
+    counts, total = per_repo_counts_for_window(client, "onfleet", window)
+
+    # Total preserved from per-half head probes.
+    assert total == 700 + 800
+    # Per-repo counts merged across halves.
+    assert counts == {"api": 2, "web": 2, "docs": 1}
+    # Three head probes (full window + 2 halves) confirms the recursive split fired.
+    head_calls = [params for _url, params in session.calls if params and params.get("per_page") == 1]
+    assert len(head_calls) == 3
+
+
+def test_collect_report_in_verbose_mode_attaches_per_repo_counts() -> None:
+    responses = [
+        # April: head + one page
+        _StubResponse(200, {"total_count": 3, "items": []}),
+        _StubResponse(200, _items_payload(["api", "api", "web"], total=3)),
+        # May: head + one page
+        _StubResponse(200, {"total_count": 2, "items": []}),
+        _StubResponse(200, _items_payload(["api", "docs"], total=2)),
+    ]
+    client, _session, _sleeps = _make_client(responses)
+
+    report = collect_report(
+        client,
+        "onfleet",
+        date(2025, 4, 1),
+        date(2025, 5, 31),
+        verbose=True,
+        sleep_fn=lambda _s: None,
+        pause_seconds=0,
+    )
+
+    assert [row.merged_prs for row in report.rows] == [3, 2]
+    assert report.rows[0].per_repo == {"api": 2, "web": 1}
+    assert report.rows[1].per_repo == {"api": 1, "docs": 1}
+    assert report.total == 5
+
+
+def test_render_table_in_verbose_mode_shows_per_repo_block_above_totals() -> None:
+    responses = [
+        _StubResponse(200, {"total_count": 3, "items": []}),
+        _StubResponse(200, _items_payload(["api", "api", "web"], total=3)),
+    ]
+    client, _session, _sleeps = _make_client(responses)
+    report = collect_report(
+        client,
+        "onfleet",
+        date(2025, 4, 1),
+        date(2025, 4, 30),
+        verbose=True,
+        sleep_fn=lambda _s: None,
+        pause_seconds=0,
+    )
+    rendered = render_table(report)
+    breakdown_index = rendered.find("Per-repo merged PRs")
+    totals_header_index = rendered.find("Org: onfleet")
+    assert breakdown_index != -1
+    assert totals_header_index != -1
+    assert breakdown_index < totals_header_index
+    assert "2025-04  (3 total)" in rendered
+    # Repos sorted by count desc, then name.
+    api_index = rendered.find("api")
+    web_index = rendered.find("web")
+    assert api_index < web_index
+
+
+def test_render_json_in_verbose_mode_includes_per_repo_object() -> None:
+    responses = [
+        _StubResponse(200, {"total_count": 3, "items": []}),
+        _StubResponse(200, _items_payload(["api", "api", "web"], total=3)),
+    ]
+    client, _session, _sleeps = _make_client(responses)
+    report = collect_report(
+        client,
+        "onfleet",
+        date(2025, 4, 1),
+        date(2025, 4, 30),
+        verbose=True,
+        sleep_fn=lambda _s: None,
+        pause_seconds=0,
+    )
+    payload = json.loads(render_json(report))
+    assert payload["rows"][0]["per_repo"] == {"api": 2, "web": 1}
+
+
+def test_render_csv_in_verbose_mode_emits_per_repo_rows() -> None:
+    responses = [
+        _StubResponse(200, {"total_count": 3, "items": []}),
+        _StubResponse(200, _items_payload(["api", "api", "web"], total=3)),
+    ]
+    client, _session, _sleeps = _make_client(responses)
+    report = collect_report(
+        client,
+        "onfleet",
+        date(2025, 4, 1),
+        date(2025, 4, 30),
+        verbose=True,
+        sleep_fn=lambda _s: None,
+        pause_seconds=0,
+    )
+    rendered = render_csv(report)
+    lines = rendered.splitlines()
+    assert lines[0] == "month,repo,merged_prs"
+    assert lines[1] == "2025-04,api,2"
+    assert lines[2] == "2025-04,web,1"
+    assert lines[3] == "2025-04,(month total),3"
+    assert lines[-1] == "TOTAL,,3"
+
+
+def test_argument_parser_accepts_short_v_flag() -> None:
+    parser = build_argument_parser()
+    args = parser.parse_args(["--from", "2025-01-01", "--to", "2025-12-31", "-v"])
+    assert args.verbose is True
+    args_default = parser.parse_args(["--from", "2025-01-01", "--to", "2025-12-31"])
+    assert args_default.verbose is False
+
+
+def test_month_windows_sanity_check_for_year_boundaries() -> None:
+    # Guard against off-by-one when the range spans Dec/Jan.
+    windows = month_windows(date(2024, 12, 15), date(2025, 1, 5))
+    assert [w.label for w in windows] == ["2024-12", "2025-01"]
+    assert windows[0].start == date(2024, 12, 15)
+    assert windows[0].end == date(2024, 12, 31)
+    assert windows[1].start == date(2025, 1, 1)
+    assert windows[1].end == date(2025, 1, 5)

--- a/tests/unit/git_metrics/test_org_merged_prs_per_month.py
+++ b/tests/unit/git_metrics/test_org_merged_prs_per_month.py
@@ -156,6 +156,19 @@ def test_collect_report_rejects_inverted_range() -> None:
         collect_report(client, "onfleet", date(2025, 6, 1), date(2025, 5, 1), sleep_fn=lambda _s: None)
 
 
+def test_collect_report_rejects_future_end_date() -> None:
+    client, _session, _sleeps = _make_client([])
+    with pytest.raises(ValueError, match="future"):
+        collect_report(
+            client,
+            "onfleet",
+            date(2026, 5, 1),
+            date(2026, 6, 1),
+            today=date(2026, 5, 8),
+            sleep_fn=lambda _s: None,
+        )
+
+
 def _sample_report():
     return collect_report(
         *_make_collect_inputs(),
@@ -569,6 +582,43 @@ def test_loc_for_window_retries_when_graphql_returns_200_with_rate_limit_error()
     assert (additions, deletions, total) == (5, 2, 1)
     assert sleeps == [1.0]
     assert len(client.rate_limit_events) == 1
+
+
+def test_render_csv_in_verbose_plus_loc_mode_includes_per_repo_and_loc_columns() -> None:
+    responses = [
+        # Verbose path: head + page-1 with 3 items
+        _StubResponse(200, {"total_count": 3, "items": []}),
+        _StubResponse(200, _items_payload(["api", "api", "web"], total=3)),
+        # LOC path: GraphQL with 3 PRs
+        _graphql_response(
+            total=3,
+            nodes=[
+                {"additions": 100, "deletions": 30},
+                {"additions": 50, "deletions": 20},
+                {"additions": 7, "deletions": 1},
+            ],
+        ),
+    ]
+    client, _session, _sleeps = _make_client(responses)
+    report = collect_report(
+        client,
+        "onfleet",
+        date(2025, 4, 1),
+        date(2025, 4, 30),
+        verbose=True,
+        loc=True,
+        sleep_fn=lambda _s: None,
+        pause_seconds=0,
+    )
+    rendered = render_csv(report)
+    lines = rendered.splitlines()
+    assert lines[0] == "month,repo,merged_prs,additions,deletions"
+    # Per-repo rows leave additions/deletions blank (per-repo LOC not collected in v1).
+    assert lines[1] == "2025-04,api,2,,"
+    assert lines[2] == "2025-04,web,1,,"
+    # Per-month total carries the LOC totals.
+    assert lines[3] == "2025-04,(month total),3,157,51"
+    assert lines[-1] == "TOTAL,,3,157,51"
 
 
 def test_argument_parser_accepts_short_l_flag() -> None:


### PR DESCRIPTION
## Summary
Adds a standalone org-scoped CLI that reports merged PR counts per month, with optional per-repo breakdowns and monthly additions/deletions totals.
- Count-only mode uses GitHub Search `total_count`, so each month is one cheap REST call.
- Verbose and LOC modes paginate results and recursively split date ranges when GitHub Search would exceed the 1000-result cap.

## Changes
- **CLI / Behavior**:
  - Adds `git_metrics/org_merged_prs_per_month.py` with `--from`, `--to`, `--owner`, `--token-env`, `--format {table,json,csv}`, `-v/--verbose`, and `-l/--loc`.
  - `--owner` falls back to `GITHUB_METRIC_OWNER_OR_ORGANIZATION` and is explicitly org-scoped (`org:<owner>`); user accounts are not supported.
  - Supports both `python3 -m git_metrics.org_merged_prs_per_month ...` and direct script-path help via `python3 git_metrics/org_merged_prs_per_month.py --help`.
  - Help output includes copy-pasteable examples and calls out that `-v` / `--verbose` is valid, not `--v`.
  - Rejects inverted ranges and future `--to` dates to avoid misleading future zero-data rows.
  - Adds 250 ms baseline pacing between requests as defensive insurance against secondary rate limits.
- **Counting / LOC**:
  - Reuses `GitHubClient` from `git_metrics/ci_maturity_report.py` for REST rate-limit handling.
  - Reuses `MonthWindow` and `month_windows()` from `git_metrics/throughput_collect.py`.
  - Verbose per-repo mode paginates Search API results, stops at the page-10 Search cap, and recursively halves windows above 1000 results.
  - `--loc` uses GraphQL Search to sum PR `additions` and `deletions`, with GraphQL rate-limit retry handling and recursive range splitting above 1000 results.
- **Output**:
  - Table, JSON, and CSV output include month rows and totals.
  - Verbose output adds per-repo counts.
  - LOC output adds additions/deletions columns and totals; verbose+LOC CSV leaves per-repo LOC cells blank because per-repo LOC is not collected in this revision, while `(month total)` rows carry the LOC totals.
- **Tests**:
  - Adds `tests/unit/git_metrics/test_org_merged_prs_per_month.py` covering query construction, month clamping, future-date rejection, rate-limit retry paths, pagination, recursive cap splitting, output formats, parser flags, script-path help, and verbose+LOC CSV behavior.

## Validation
- [x] **Unit tests for changed git metrics code**: Action: run `python3 -m pytest tests/unit/git_metrics/test_org_merged_prs_per_month.py --no-header`. Expected: 29 tests pass.
- [x] **Git metrics unit test suite**: Action: run `python3 -m pytest tests/unit/git_metrics/ --no-header`. Expected: 49 tests pass.
- [x] **Full local test suite with CI coverage gate**: Action: run `python3 -m pytest --cov --junitxml=junit.xml -o junit_family=legacy --cov-branch --cov-fail-under=47 --no-header`. Expected: 178 tests pass and coverage remains above 47%.
- [x] **Help walkthrough**: Action: run `python3 git_metrics/org_merged_prs_per_month.py --help` and `python3 -m git_metrics.org_merged_prs_per_month --help`. Expected: both commands print usage, examples, and the note to place `git_metrics.org_merged_prs_per_month` immediately after `-m`.
- [x] **Manual CLI walkthrough**: Prerequisites: `.env` or environment values for `GITHUB_TOKEN_READONLY_WEB` and `GITHUB_METRIC_OWNER_OR_ORGANIZATION`. Action: run `python3 -m git_metrics.org_merged_prs_per_month --from 2025-05-01 --to 2026-05-08`, then repeat with `--format json`, `--format csv`, `-v`, and `--loc`. Expected: one row per month plus totals; verbose output includes per-repo rows; LOC output includes additions/deletions totals.
- [ ] **Future-date guard**: Action: run `python3 -m git_metrics.org_merged_prs_per_month --from 2026-05-09 --to 2026-05-09 --owner example --token-env GITHUB_TOKEN_READONLY_WEB`. Expected: command exits non-zero with an error that `--to` is in the future.

Watch for: counts are token-scoped, so a token without private-repo access will under-report private repositories.

## Notes
- Pylint score checks were run locally: touched files scored 9.84/10 and all tracked Python files scored 9.69/10, above the workflow threshold of 9.50. Raw pylint exits non-zero because the repo already has existing lint findings and pylint returns non-zero even when the score gate would pass.

<pre>
     ▐▛███▜▌
    ▝▜█████▛▘
      ▘▘ ▝▝
Quest/Co-Authored by
Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
Co-Authored-By: Codex <noreply@openai.com>
in collaboration with KjellKod
</pre>
