### PR TITLE
Pin Codecov action to commit SHA

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -46,7 +46,7 @@ jobs:
       # Skip on Dependabot PRs: they don't get access to Actions secrets,
       # so CODECOV_TOKEN is empty and the upload would fail.
       if: ${{ !cancelled() && github.actor != 'dependabot[bot]' }}
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         fail_ci_if_error: false


### PR DESCRIPTION
## Summary
Pins the third-party Codecov action to an immutable commit SHA to reduce workflow supply-chain risk.

## Changes
- **CI/Workflows**:
  - Replace `codecov/codecov-action@v4` with `codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0`.
  - Preserve the existing `CODECOV_TOKEN`, Dependabot skip guard, and `fail_ci_if_error: false`.

## Validation
- [x] Run `grep -nE 'codecov/codecov-action@[0-9a-f]{40}.*# v4\.6\.0$' .github/workflows/python-ci.yml`.
- [ ] Confirm repo secret `CODECOV_TOKEN` exists: Settings -> Secrets and variables -> Actions.

## Notes
- SHA provenance: `refs/tags/v4` and `refs/tags/v4.6.0^{}` currently resolve to `b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238`.

<pre>
     ▐▛███▜▌
    ▝▜█████▛▘
      ▘▘ ▝▝
Quest/Co-Authored by
Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
Co-Authored-By: Codex <noreply@openai.com>
in collaboration with KjellKod
</pre>