### PR TITLE
Add CODEOWNERS and Dependabot config

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,8 @@
+# Ownership for CI/CD and repository governance files.
+* @KjellKod
+/.github/ @KjellKod
+/.github/workflows/ @KjellKod
+/.github/dependabot.yml @KjellKod
+/.github/CODEOWNERS @KjellKod
+/requirements.txt @KjellKod
+/pyproject.toml @KjellKod

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,24 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    groups:
+      actions-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+  - package-ecosystem: pip
+    directory: "/"
+    schedule:
+      interval: weekly
+    groups:
+      pip-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch


### PR DESCRIPTION
## Summary
Adds ownership and grouped dependency update routing for repo automation hardening.
- CODEOWNERS routes `.github/` and CI/CD-affecting files to `@KjellKod`.
- Dependabot covers `github-actions` and `pip` weekly with grouped minor/patch updates.

## Changes
- **Repository governance**:
  - Add `.github/CODEOWNERS` with `@KjellKod` ownership for `.github/`, workflows, Dependabot config, CODEOWNERS, `requirements.txt`, and `pyproject.toml`.
- **Dependabot**:
  - Add `.github/dependabot.yml` for weekly `github-actions` and `pip` updates.
  - Group minor/patch updates and avoid deprecated `reviewers:` / `assignees:` keys.

## Validation
- [x] Run `python3 - <<'PY'
import yaml
yaml.safe_load(open(".github/dependabot.yml"))
assert "/.github/ @KjellKod" in open(".github/CODEOWNERS").read()
print("ok")
PY`

## Notes
- Do not enable branch protection settings that combine required approvals with "Require review from Code Owners" if Dependabot patch/minor auto-merge should remain low-friction.

<pre>
     ▐▛███▜▌
    ▝▜█████▛▘
      ▘▘ ▝▝
Quest/Co-Authored by
Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
Co-Authored-By: Codex <noreply@openai.com>
in collaboration with KjellKod
</pre>