### PR TITLE
Add Pylint workflow permissions

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -2,6 +2,9 @@ name: Pylint
 
 on: [push]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
Adds an explicit read-only token permissions block to the Pylint workflow.

## Changes
- **CI/Workflows**:
  - Add top-level `permissions: contents: read` before `jobs:` in `.github/workflows/pylint.yml`.
  - Leave triggers, matrix, Node 20 env, and pylint score logic unchanged.

## Validation
- [x] Run `awk '/^permissions:/{found=1} /^jobs:/{exit} END{exit !found}' .github/workflows/pylint.yml`.
- [ ] In GitHub UI, verify Settings -> Actions -> General uses read-only workflow permissions and Actions cannot create/approve PRs.

## Notes
- Manual UI still needed: branch protection on `main`, first-time/outside contributor approval, secret scanning + push protection, Dependency Review, and CodeQL default setup for Python.

<pre>
     ▐▛███▜▌
    ▝▜█████▛▘
      ▘▘ ▝▝
Quest/Co-Authored by
Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
Co-Authored-By: Codex <noreply@openai.com>
in collaboration with KjellKod
</pre>