### PR TITLE
Add Jira epic membership history audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,43 @@ The output includes:
   - Helps identify completion patterns and velocity
 ```
 
+To audit historical epic membership changes from issue changelogs, use the separate
+`epic_membership_history.py` tool. Date-only boundaries default to `America/Denver`
+(Mountain time with daylight-saving transitions); override that default with `--timezone`.
+Full timestamps must still include an explicit UTC offset or `Z`:
+
+```bash
+# Audit one epic over an inclusive interval
+python3 jira_metrics/epic_membership_history.py \
+  --epic <EPIC_KEY> \
+  --since <YYYY-MM-DD> \
+  --until <YYYY-MM-DD>
+
+# Audit every accessible Epic currently carrying a label and export event rows
+python3 jira_metrics/epic_membership_history.py \
+  --label <LABEL> \
+  --since <ISO_8601_TIMESTAMP_WITH_OFFSET> \
+  --timezone <IANA_TIMEZONE> \
+  --csv <OUTPUT_PATH> \
+  --verbose
+```
+
+A date-only `--since` resolves to the start of that day, while a date-only `--until`
+resolves to the end of that day. The CLI prints the resolved inclusive interval and offsets
+before making its first Jira request. Naive clock timestamps such as
+`2026-07-06T12:00:00` remain invalid because they do not identify an unambiguous instant.
+
+The audit uses the Jira credentials loaded from the root `.env`, searches all accessible
+projects using a broad current `updated` boundary, fetches complete changelogs, and filters
+events locally to the exact interval. Terminal events are shown as width-limited chronological
+cards so every evidence field remains readable without horizontal scrolling; CSV exports retain
+the same data as flat event rows. Label selection finds only accessible Epics that carry the
+label now; an Epic whose label was removed earlier cannot be discovered that way. Jira permissions
+or issue security can hide issues or history. Current parent and status columns are execution-time
+snapshots. Failed pages, unresolved histories, or unknown relationship snapshots are reported as
+limitations with a nonzero exit status. CSV fields contain untrusted Jira text; review them before
+opening an export in spreadsheet software.
+
 To analyze engineering excellence:
 ```bash
 python3 jira_metrics/engineering_excellence.py

--- a/README.md
+++ b/README.md
@@ -291,7 +291,8 @@ label now; an Epic whose label was removed earlier cannot be discovered that way
 or issue security can hide issues or history. Current parent and status columns are execution-time
 snapshots. Failed pages, unresolved histories, or unknown relationship snapshots are reported as
 limitations with a nonzero exit status. CSV fields contain untrusted Jira text; review them before
-opening an export in spreadsheet software.
+opening an export in spreadsheet software. Formula-like cells are prefixed with an apostrophe so
+spreadsheet applications treat them as text instead of evaluating them.
 
 To analyze engineering excellence:
 ```bash

--- a/jira_metrics/epic_membership_history.py
+++ b/jira_metrics/epic_membership_history.py
@@ -33,6 +33,7 @@ DEFAULT_INPUT_TIMEZONE = "America/Denver"
 KNOWN_RELATIONSHIP_NAMES = {"parent", "epiclink", "issueparentassociation"}
 EMPTY_RELATIONSHIP_VALUES = {"", "none", "null", "no epic", "no parent"}
 JIRA_KEY_AT_START = re.compile(r"^\s*\[?([A-Za-z][A-Za-z0-9_]*-\d+)\b")
+CSV_FORMULA_PREFIXES = ("=", "+", "-", "@", "\t", "\r")
 
 EVENT_COLUMNS = (
     "Epic key",
@@ -260,6 +261,14 @@ def parse_jira_timestamp(value: Any) -> datetime:
     if parsed.tzinfo is None or parsed.utcoffset() is None:
         raise ValueError("Jira timestamp is not timezone-aware")
     return parsed
+
+
+def _history_id_sort_key(history_id: str) -> tuple[int, int | str]:
+    """Sort Jira's numeric history IDs numerically with a stable text fallback."""
+    stripped = history_id.strip()
+    if stripped.isdecimal():
+        return (0, int(stripped))
+    return (1, stripped.casefold())
 
 
 def _quote_jql(value: str) -> str:
@@ -500,7 +509,14 @@ def normalize_changelog_records(
             if record.identity not in seen:
                 evidence.append(record)
                 seen.add(record.identity)
-    evidence.sort(key=lambda record: (record.timestamp, record.history_id, record.field_id, record.field_name))
+    evidence.sort(
+        key=lambda record: (
+            record.timestamp,
+            _history_id_sort_key(record.history_id),
+            record.field_id,
+            record.field_name,
+        )
+    )
     return evidence, limitations
 
 
@@ -561,7 +577,7 @@ def classify_membership_events(  # pylint: disable=too-many-arguments,too-many-p
         key=lambda event: (
             event.evidence.timestamp,
             event.issue.key,
-            event.evidence.history_id,
+            _history_id_sort_key(event.evidence.history_id),
             event.epic_key,
             event.event_type,
         )
@@ -641,7 +657,17 @@ def write_csv(events: list[MembershipEvent], path: Path) -> None:
     with path.open("w", encoding="utf-8", newline="") as output:
         writer = csv.DictWriter(output, fieldnames=EVENT_COLUMNS)
         writer.writeheader()
-        writer.writerows(event_to_row(event) for event in events)
+        for event in events:
+            row = event_to_row(event)
+            writer.writerow({column: _spreadsheet_safe_cell(value) for column, value in row.items()})
+
+
+def _spreadsheet_safe_cell(value: str) -> str:
+    """Prevent untrusted Jira text from being evaluated as a spreadsheet formula."""
+    meaningful = value.lstrip()
+    if meaningful.startswith(CSV_FORMULA_PREFIXES):
+        return "'" + value
+    return value
 
 
 def _summary_for_events(

--- a/jira_metrics/epic_membership_history.py
+++ b/jira_metrics/epic_membership_history.py
@@ -1,0 +1,838 @@
+#!/usr/bin/env python3
+"""Audit Jira epic membership changes from complete issue changelogs."""
+
+# pylint: disable=import-error
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import re
+import shutil
+import sys
+import textwrap
+from dataclasses import dataclass, field
+from datetime import date, datetime, time, timedelta, timezone
+from pathlib import Path
+from typing import Any, Sequence
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+from jira_utils import (
+    ChangelogFetchResult,
+    JiraFieldResult,
+    JiraSearchResult,
+    fetch_complete_changelogs,
+    get_jira_field_metadata,
+    search_jira_issues_raw,
+)
+
+
+CANDIDATE_CUSHION_DAYS = 2
+DEFAULT_INPUT_TIMEZONE = "America/Denver"
+KNOWN_RELATIONSHIP_NAMES = {"parent", "epiclink", "issueparentassociation"}
+EMPTY_RELATIONSHIP_VALUES = {"", "none", "null", "no epic", "no parent"}
+JIRA_KEY_AT_START = re.compile(r"^\s*\[?([A-Za-z][A-Za-z0-9_]*-\d+)\b")
+
+EVENT_COLUMNS = (
+    "Epic key",
+    "Issue key",
+    "Issue summary",
+    "Issue type",
+    "Current status",
+    "Event type",
+    "Event timestamp",
+    "Actor display name",
+    "Actor account ID",
+    "Previous parent/epic",
+    "New parent/epic",
+    "Current parent/epic",
+    "Later re-added",
+    "Changelog field name",
+    "Changelog/history ID",
+    "Raw changelog evidence",
+)
+
+
+class AuditError(RuntimeError):
+    """An actionable fatal audit error."""
+
+
+@dataclass(frozen=True)
+class EpicRef:
+    key: str
+    issue_id: str
+
+
+@dataclass(frozen=True)
+class RelationshipFields:
+    field_ids: frozenset[str]
+    field_names: frozenset[str]
+    display_names_by_id: dict[str, str]
+
+    def recognizes(self, field_name: str, field_id: str) -> bool:
+        return normalize_field_name(field_name) in self.field_names or field_id.casefold() in self.field_ids
+
+
+@dataclass(frozen=True)
+class IssueSnapshot:  # pylint: disable=too-many-instance-attributes
+    key: str
+    issue_id: str
+    summary: str
+    issue_type: str
+    status: str
+    updated: str
+    current_parent: str | None
+    current_parent_state: str
+
+
+@dataclass(frozen=True)
+class ChangelogEvidence:  # pylint: disable=too-many-instance-attributes
+    issue_key: str
+    history_id: str
+    timestamp: datetime
+    actor_display_name: str
+    actor_account_id: str
+    field_name: str
+    field_id: str
+    from_value: Any
+    from_string: Any
+    to_value: Any
+    to_string: Any
+
+    @property
+    def raw_evidence(self) -> str:
+        raw = {
+            "field": self.field_name,
+            "fieldId": self.field_id,
+            "from": self.from_value,
+            "fromString": self.from_string,
+            "to": self.to_value,
+            "toString": self.to_string,
+        }
+        return json.dumps(raw, sort_keys=True, separators=(",", ":"), default=str)
+
+    @property
+    def identity(self) -> tuple[str, ...]:
+        return (
+            self.issue_key,
+            self.history_id,
+            self.field_id.casefold() or normalize_field_name(self.field_name),
+            json.dumps(
+                [self.from_value, self.from_string, self.to_value, self.to_string],
+                sort_keys=True,
+                separators=(",", ":"),
+                default=str,
+            ),
+        )
+
+
+@dataclass
+class MembershipEvent:
+    epic_key: str
+    issue: IssueSnapshot
+    event_type: str
+    evidence: ChangelogEvidence
+    previous_parent: str
+    new_parent: str
+    later_re_added: bool = False
+
+
+@dataclass(frozen=True)
+class SummaryCounts:  # pylint: disable=too-many-instance-attributes
+    unique_issues: int
+    additions: int
+    removals: int
+    moves_in: int
+    moves_out: int
+    unique_outbound_issues: int
+    later_re_added: int
+    currently_other_epic: int
+    currently_no_epic: int
+
+
+@dataclass
+class AuditDiagnostics:  # pylint: disable=too-many-instance-attributes
+    selector: str
+    resolved_epic_keys: list[str]
+    since: datetime
+    until: datetime
+    candidate_jql: str
+    candidate_count: int
+    changelog_method: str
+    every_page_complete: bool
+    audit_complete: bool
+    input_timezone: str = DEFAULT_INPUT_TIMEZONE
+    limitations: list[str] = field(default_factory=list)
+    label_selection: bool = False
+
+
+@dataclass(frozen=True)
+class AuditResult:
+    events: list[MembershipEvent]
+    summaries: dict[str, SummaryCounts]
+    overall_summary: SummaryCounts
+    diagnostics: AuditDiagnostics
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Reconstruct Jira epic membership changes from issue-level changelog evidence."
+    )
+    selector = parser.add_mutually_exclusive_group(required=True)
+    selector.add_argument("--epic", help="Audit one Epic key")
+    selector.add_argument("--label", help="Audit all accessible Epics currently carrying this label")
+    parser.add_argument(
+        "--since",
+        required=True,
+        help="Inclusive ISO-8601 start; YYYY-MM-DD uses start-of-day in --timezone",
+    )
+    parser.add_argument(
+        "--until",
+        help="Inclusive ISO-8601 end; YYYY-MM-DD uses end-of-day in --timezone; defaults to now",
+    )
+    parser.add_argument(
+        "--timezone",
+        default=DEFAULT_INPUT_TIMEZONE,
+        help=f"IANA timezone for date-only boundaries (default: {DEFAULT_INPUT_TIMEZONE})",
+    )
+    parser.add_argument("--csv", dest="csv_path", type=Path, help="Export the displayed event rows to CSV")
+    parser.add_argument("-v", "--verbose", action="store_true", help="Print sanitized retrieval diagnostics")
+    args = parser.parse_args(argv)
+    args.since_input = args.since
+    args.until_input = args.until
+    try:
+        input_timezone = ZoneInfo(args.timezone)
+    except ZoneInfoNotFoundError:
+        parser.error(f"unknown IANA timezone: {args.timezone}")
+    try:
+        args.since = parse_audit_boundary(args.since, input_timezone, end_of_day=False)
+        if args.until is not None:
+            args.until = parse_audit_boundary(args.until, input_timezone, end_of_day=True)
+    except argparse.ArgumentTypeError as exc:
+        parser.error(str(exc))
+    if args.until is not None and args.until < args.since:
+        parser.error("--until must be the same as or later than --since")
+    return args
+
+
+def parse_aware_timestamp(value: str) -> datetime:
+    normalized = value[:-1] + "+00:00" if value.endswith(("Z", "z")) else value
+    try:
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(f"invalid ISO-8601 timestamp: {value}") from exc
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise argparse.ArgumentTypeError("timestamp must include an explicit UTC offset or Z")
+    return parsed
+
+
+def parse_audit_boundary(value: str, input_timezone: ZoneInfo, *, end_of_day: bool) -> datetime:
+    """Resolve a CLI boundary while keeping naive clock timestamps invalid."""
+    if re.fullmatch(r"\d{4}-\d{2}-\d{2}", value):
+        try:
+            parsed_date = date.fromisoformat(value)
+        except ValueError as exc:
+            raise argparse.ArgumentTypeError(f"invalid ISO-8601 date: {value}") from exc
+        boundary_time = time.max if end_of_day else time.min
+        return datetime.combine(parsed_date, boundary_time, tzinfo=input_timezone)
+    return parse_aware_timestamp(value)
+
+
+def print_resolved_interval(args: argparse.Namespace, until: datetime) -> None:
+    """Confirm the exact inclusive interval before any Jira request."""
+    until_input = args.until_input if args.until_input is not None else "(now)"
+    print("Resolved audit interval:")
+    print(f"  --since {args.since_input} -> {args.since.isoformat()}")
+    print(f"  --until {until_input} -> {until.isoformat()}")
+    print(f"  Date-only timezone: {args.timezone}")
+    print("  Boundaries: inclusive")
+
+
+def parse_jira_timestamp(value: Any) -> datetime:
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        seconds = float(value) / 1000 if abs(float(value)) >= 100_000_000_000 else float(value)
+        return datetime.fromtimestamp(seconds, tz=timezone.utc)
+    if not isinstance(value, str):
+        raise ValueError("unsupported Jira timestamp")
+    normalized = value[:-1] + "+00:00" if value.endswith(("Z", "z")) else value
+    parsed = datetime.fromisoformat(normalized)
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise ValueError("Jira timestamp is not timezone-aware")
+    return parsed
+
+
+def _quote_jql(value: str) -> str:
+    return '"' + value.replace("\\", "\\\\").replace('"', '\\"') + '"'
+
+
+def build_selector_jql(epic: str | None = None, label: str | None = None) -> str:
+    if epic:
+        return f"key = {_quote_jql(epic.strip())} AND issuetype = Epic"
+    if label:
+        return f"issuetype = Epic AND labels = {_quote_jql(label)} ORDER BY key ASC"
+    raise ValueError("An epic key or label is required")
+
+
+def build_candidate_jql(since: datetime) -> str:
+    boundary = (since.astimezone(timezone.utc) - timedelta(days=CANDIDATE_CUSHION_DAYS)).replace(
+        hour=0, minute=0, second=0, microsecond=0
+    )
+    return f'updated >= "{boundary:%Y-%m-%d %H:%M}" ORDER BY updated ASC'
+
+
+def normalize_field_name(value: str) -> str:
+    return "".join(character for character in value.casefold() if character.isalnum())
+
+
+def discover_relationship_fields(metadata: list[dict[str, Any]]) -> RelationshipFields:
+    names = set(KNOWN_RELATIONSHIP_NAMES)
+    field_ids = {"parent", "issueparentassociation"}
+    display_names_by_id = {"parent": "Parent", "issueparentassociation": "IssueParentAssociation"}
+    for item in metadata:
+        name = item.get("name")
+        field_id = item.get("id") or item.get("key")
+        if not isinstance(name, str) or not isinstance(field_id, str):
+            continue
+        normalized_name = normalize_field_name(name)
+        if normalized_name in KNOWN_RELATIONSHIP_NAMES:
+            names.add(normalized_name)
+            field_ids.add(field_id.casefold())
+            display_names_by_id[field_id.casefold()] = name
+    return RelationshipFields(frozenset(field_ids), frozenset(names), display_names_by_id)
+
+
+def _epic_type(raw_issue: dict[str, Any]) -> bool:
+    fields = raw_issue.get("fields", {})
+    issue_type = fields.get("issuetype", {}) if isinstance(fields, dict) else {}
+    name = issue_type.get("name", "") if isinstance(issue_type, dict) else ""
+    return isinstance(name, str) and name.casefold() == "epic"
+
+
+def resolve_epics(epic: str | None, label: str | None) -> list[EpicRef]:
+    jql = build_selector_jql(epic=epic, label=label)
+    result = search_jira_issues_raw(jql, ["issuetype"])
+    if not result.complete:
+        details = " ".join(result.limitations)
+        raise AuditError(f"Epic selector query was incomplete. {details}")
+    refs = [
+        EpicRef(str(issue["key"]), str(issue["id"]))
+        for issue in result.issues
+        if "key" in issue and "id" in issue and _epic_type(issue)
+    ]
+    if epic:
+        refs = [ref for ref in refs if ref.key.casefold() == epic.strip().casefold()]
+        if not refs:
+            raise AuditError(f"{epic} was not found as an accessible Epic. Check the key and permissions.")
+        return refs[:1]
+    return sorted(refs, key=lambda ref: ref.key)
+
+
+def _relationship_display_value(raw_value: Any, string_value: Any = None) -> str:
+    for value in (string_value, raw_value):
+        if isinstance(value, dict):
+            for key in ("key", "id"):
+                nested = value.get(key)
+                if nested not in (None, ""):
+                    return str(nested)
+        if value not in (None, ""):
+            return str(value)
+    return "(none)"
+
+
+def _value_is_empty(raw_value: Any, string_value: Any) -> bool:
+    present = [value for value in (raw_value, string_value) if value is not None]
+    if not present:
+        return True
+    return all(str(value).strip().casefold() in EMPTY_RELATIONSHIP_VALUES for value in present)
+
+
+def _selected_epic_for_value(raw_value: Any, string_value: Any, epics: list[EpicRef]) -> str | None:
+    aliases = {ref.issue_id.casefold(): ref.key for ref in epics}
+    aliases.update({ref.key.casefold(): ref.key for ref in epics})
+    if isinstance(raw_value, dict):
+        candidates = [raw_value.get("id"), raw_value.get("key")]
+    else:
+        candidates = [raw_value]
+    meaningful_candidates = [
+        str(candidate).strip().casefold()
+        for candidate in candidates
+        if candidate is not None and str(candidate).strip().casefold() not in EMPTY_RELATIONSHIP_VALUES
+    ]
+    for candidate in meaningful_candidates:
+        if candidate in aliases:
+            return aliases[candidate]
+    if meaningful_candidates:
+        return None
+    if isinstance(string_value, str):
+        exact = string_value.strip().casefold()
+        if exact in aliases:
+            return aliases[exact]
+        match = JIRA_KEY_AT_START.match(string_value)
+        if match and match.group(1).casefold() in aliases:
+            return aliases[match.group(1).casefold()]
+    return None
+
+
+def _current_relationship_value(value: Any) -> str | None:
+    if value in (None, ""):
+        return None
+    if isinstance(value, dict):
+        for key in ("key", "id", "value"):
+            nested = value.get(key)
+            if nested not in (None, ""):
+                return str(nested)
+        return None
+    return str(value)
+
+
+def build_issue_snapshots(  # pylint: disable=too-many-locals
+    raw_issues: list[dict[str, Any]], relationship_fields: RelationshipFields
+) -> tuple[dict[str, IssueSnapshot], list[str]]:
+    snapshots: dict[str, IssueSnapshot] = {}
+    limitations: list[str] = []
+    for raw_issue in raw_issues:
+        raw_key = raw_issue.get("key")
+        if not isinstance(raw_key, str) or not raw_key.strip():
+            limitations.append("A candidate issue was omitted because Jira did not return its key.")
+            continue
+        key = raw_key
+        fields = raw_issue.get("fields")
+        fields_available = isinstance(fields, dict)
+        if not isinstance(fields, dict):
+            limitations.append(f"Current relationship for {key} is unknown because issue fields were unavailable.")
+            fields = {}
+        values: list[str] = []
+        recognized_present = False
+        for field_id, value in fields.items():
+            if not isinstance(field_id, str):
+                continue
+            if (
+                field_id.casefold() in relationship_fields.field_ids
+                or normalize_field_name(field_id) in KNOWN_RELATIONSHIP_NAMES
+            ):
+                recognized_present = True
+                current = _current_relationship_value(value)
+                if current:
+                    values.append(current)
+        unique_values = {value.casefold(): value for value in values}
+        if len(unique_values) > 1:
+            state = "unknown"
+            current_parent = None
+            limitations.append(f"Current relationship for {key} is unknown because Jira relationship fields conflict.")
+        elif len(unique_values) == 1:
+            state = "known"
+            current_parent = next(iter(unique_values.values()))
+        elif recognized_present:
+            state = "empty"
+            current_parent = None
+        elif not fields_available:
+            state = "unknown"
+            current_parent = None
+        else:
+            # Jira omits requested fields whose values are null from enhanced
+            # search responses. No returned relationship field therefore means
+            # the issue currently has no parent/epic, provided the issue fields
+            # object itself was available.
+            state = "empty"
+            current_parent = None
+
+        issue_type = fields.get("issuetype", {})
+        status = fields.get("status", {})
+        snapshots[key] = IssueSnapshot(
+            key=key,
+            issue_id=str(raw_issue.get("id", "")),
+            summary=str(fields.get("summary") or ""),
+            issue_type=str(issue_type.get("name") or "") if isinstance(issue_type, dict) else "",
+            status=str(status.get("name") or "") if isinstance(status, dict) else "",
+            updated=str(fields.get("updated") or ""),
+            current_parent=current_parent,
+            current_parent_state=state,
+        )
+    return snapshots, limitations
+
+
+def normalize_changelog_records(
+    issue_key: str,
+    histories: list[dict[str, Any]],
+    relationship_fields: RelationshipFields,
+) -> tuple[list[ChangelogEvidence], list[str]]:
+    evidence: list[ChangelogEvidence] = []
+    limitations: list[str] = []
+    seen: set[tuple[str, ...]] = set()
+    for history in histories:
+        history_id = str(history.get("id", ""))
+        try:
+            timestamp = parse_jira_timestamp(history.get("created"))
+        except (ValueError, OverflowError, OSError):
+            limitations.append(
+                f"Changelog history {history_id or '(unknown)'} for {issue_key} had an invalid timestamp."
+            )
+            continue
+        author = history.get("author") if isinstance(history.get("author"), dict) else {}
+        items = history.get("items", [])
+        if not isinstance(items, list):
+            limitations.append(f"Changelog history {history_id or '(unknown)'} for {issue_key} had invalid items.")
+            continue
+        for item in items:
+            if not isinstance(item, dict):
+                limitations.append(
+                    f"Changelog history {history_id or '(unknown)'} for {issue_key} had an invalid item."
+                )
+                continue
+            field_name = str(item.get("field") or "")
+            field_id = str(item.get("fieldId") or "")
+            if not relationship_fields.recognizes(field_name, field_id):
+                continue
+            record = ChangelogEvidence(
+                issue_key=issue_key,
+                history_id=history_id,
+                timestamp=timestamp,
+                actor_display_name=str(author.get("displayName") or ""),
+                actor_account_id=str(author.get("accountId") or ""),
+                field_name=field_name,
+                field_id=field_id,
+                from_value=item.get("from"),
+                from_string=item.get("fromString"),
+                to_value=item.get("to"),
+                to_string=item.get("toString"),
+            )
+            if record.identity not in seen:
+                evidence.append(record)
+                seen.add(record.identity)
+    evidence.sort(key=lambda record: (record.timestamp, record.history_id, record.field_id, record.field_name))
+    return evidence, limitations
+
+
+def classify_membership_events(  # pylint: disable=too-many-arguments,too-many-positional-arguments,too-many-locals
+    snapshots: dict[str, IssueSnapshot],
+    histories_by_issue: dict[str, list[dict[str, Any]]],
+    epics: list[EpicRef],
+    relationship_fields: RelationshipFields,
+    since: datetime,
+    until: datetime,
+) -> tuple[list[MembershipEvent], list[str]]:
+    events: list[MembershipEvent] = []
+    limitations: list[str] = []
+    exited: set[tuple[str, str]] = set()
+
+    for issue_key, snapshot in snapshots.items():
+        evidence, issue_limitations = normalize_changelog_records(
+            issue_key, histories_by_issue.get(issue_key, []), relationship_fields
+        )
+        limitations.extend(issue_limitations)
+        for record in evidence:
+            if record.timestamp > until:
+                continue
+            previous_epic = _selected_epic_for_value(record.from_value, record.from_string, epics)
+            new_epic = _selected_epic_for_value(record.to_value, record.to_string, epics)
+            previous_empty = _value_is_empty(record.from_value, record.from_string)
+            new_empty = _value_is_empty(record.to_value, record.to_string)
+            previous_display = _relationship_display_value(record.from_value, record.from_string)
+            new_display = _relationship_display_value(record.to_value, record.to_string)
+
+            perspectives: list[tuple[str, str]] = []
+            if previous_epic and previous_epic != new_epic:
+                perspectives.append((previous_epic, "removed" if new_empty else "moved_out"))
+                exited.add((issue_key, previous_epic))
+            if new_epic and new_epic != previous_epic:
+                state_key = (issue_key, new_epic)
+                if state_key in exited:
+                    event_type = "re_added"
+                else:
+                    event_type = "added" if previous_empty else "moved_in"
+                perspectives.append((new_epic, event_type))
+
+            if record.timestamp < since:
+                continue
+            for epic_key, event_type in perspectives:
+                events.append(
+                    MembershipEvent(
+                        epic_key=epic_key,
+                        issue=snapshot,
+                        event_type=event_type,
+                        evidence=record,
+                        previous_parent=previous_display,
+                        new_parent=new_display,
+                    )
+                )
+
+    events.sort(
+        key=lambda event: (
+            event.evidence.timestamp,
+            event.issue.key,
+            event.evidence.history_id,
+            event.epic_key,
+            event.event_type,
+        )
+    )
+    for index, event in enumerate(events):
+        if event.event_type not in ("removed", "moved_out"):
+            continue
+        event.later_re_added = any(
+            later.issue.key == event.issue.key and later.epic_key == event.epic_key and later.event_type == "re_added"
+            for later in events[index + 1 :]
+        )
+    return events, limitations
+
+
+def _current_parent_display(issue: IssueSnapshot) -> str:
+    if issue.current_parent_state == "unknown":
+        return "Unknown"
+    return issue.current_parent or "(none)"
+
+
+def event_to_row(event: MembershipEvent) -> dict[str, str]:
+    return {
+        "Epic key": event.epic_key,
+        "Issue key": event.issue.key,
+        "Issue summary": event.issue.summary,
+        "Issue type": event.issue.issue_type,
+        "Current status": event.issue.status,
+        "Event type": event.event_type,
+        "Event timestamp": event.evidence.timestamp.isoformat(),
+        "Actor display name": event.evidence.actor_display_name,
+        "Actor account ID": event.evidence.actor_account_id,
+        "Previous parent/epic": event.previous_parent,
+        "New parent/epic": event.new_parent,
+        "Current parent/epic": _current_parent_display(event.issue),
+        "Later re-added": "yes" if event.later_re_added else "no",
+        "Changelog field name": event.evidence.field_name,
+        "Changelog/history ID": event.evidence.history_id,
+        "Raw changelog evidence": event.evidence.raw_evidence,
+    }
+
+
+def _wrapped_report_field(label: str, value: str, width: int) -> list[str]:
+    prefix = f"  {label}: "
+    continuation = " " * len(prefix)
+    available = max(1, width - len(prefix))
+    wrapped = textwrap.wrap(
+        value or "(not available)",
+        width=available,
+        break_long_words=True,
+        break_on_hyphens=False,
+    ) or [""]
+    return [prefix + wrapped[0], *(continuation + line for line in wrapped[1:])]
+
+
+def build_table_lines(events: list[MembershipEvent], width: int = 100) -> list[str]:
+    rows = [event_to_row(event) for event in events]
+    if not rows:
+        return ["No epic membership changes were found in the requested interval."]
+    width = max(40, width)
+    lines: list[str] = []
+    for index, row in enumerate(rows, start=1):
+        if lines:
+            lines.append("")
+        heading = f"Event {index} of {len(rows)}"
+        lines.extend((heading, "-" * len(heading)))
+        for column in EVENT_COLUMNS:
+            lines.extend(_wrapped_report_field(column, row[column], width))
+    return lines
+
+
+def unique_messages(messages: list[str]) -> list[str]:
+    """Deduplicate diagnostic text while preserving its first-seen order."""
+    return list(dict.fromkeys(messages))
+
+
+def write_csv(events: list[MembershipEvent], path: Path) -> None:
+    with path.open("w", encoding="utf-8", newline="") as output:
+        writer = csv.DictWriter(output, fieldnames=EVENT_COLUMNS)
+        writer.writeheader()
+        writer.writerows(event_to_row(event) for event in events)
+
+
+def _summary_for_events(
+    events: list[MembershipEvent], epic: EpicRef | None = None, epic_refs: list[EpicRef] | None = None
+) -> SummaryCounts:
+    issue_keys = {event.issue.key for event in events}
+    outbound = [event for event in events if event.event_type in ("removed", "moved_out")]
+    outbound_issues = {event.issue.key: event.issue for event in outbound}
+    later_readded = {event.issue.key for event in outbound if event.later_re_added}
+    current_aliases = {epic.key.casefold(), epic.issue_id.casefold()} if epic else set()
+    refs_by_key = {ref.key: ref for ref in epic_refs or []}
+
+    def currently_in_other_epic(issue_key: str, issue: IssueSnapshot) -> bool:
+        if issue.current_parent_state != "known" or not issue.current_parent:
+            return False
+        current = issue.current_parent.casefold()
+        if current_aliases:
+            return current not in current_aliases
+        for event in outbound:
+            if event.issue.key != issue_key:
+                continue
+            event_epic = refs_by_key.get(event.epic_key)
+            aliases = {event.epic_key.casefold()}
+            if event_epic:
+                aliases.add(event_epic.issue_id.casefold())
+            if current not in aliases:
+                return True
+        return False
+
+    return SummaryCounts(
+        unique_issues=len(issue_keys),
+        additions=sum(event.event_type == "added" for event in events),
+        removals=sum(event.event_type == "removed" for event in events),
+        moves_in=sum(event.event_type == "moved_in" for event in events),
+        moves_out=sum(event.event_type == "moved_out" for event in events),
+        unique_outbound_issues=len(outbound_issues),
+        later_re_added=len(later_readded),
+        currently_other_epic=sum(
+            currently_in_other_epic(issue_key, issue) for issue_key, issue in outbound_issues.items()
+        ),
+        currently_no_epic=sum(issue.current_parent_state == "empty" for issue in outbound_issues.values()),
+    )
+
+
+def summarize_events(
+    events: list[MembershipEvent], epics: list[EpicRef]
+) -> tuple[dict[str, SummaryCounts], SummaryCounts]:
+    summaries = {
+        epic.key: _summary_for_events([event for event in events if event.epic_key == epic.key], epic) for epic in epics
+    }
+    overall = _summary_for_events(events, epic_refs=epics)
+    return summaries, overall
+
+
+def _print_summary(title: str, summary: SummaryCounts) -> None:
+    print(f"\n{title}")
+    print(f"  Total unique issues with membership changes: {summary.unique_issues}")
+    print(f"  Total additions: {summary.additions}")
+    print(f"  Total removals to no epic: {summary.removals}")
+    print(f"  Total moves into the epic: {summary.moves_in}")
+    print(f"  Total moves out to another epic: {summary.moves_out}")
+    print(f"  Total unique issues removed or moved out: {summary.unique_outbound_issues}")
+    print(f"  Total later re-added: {summary.later_re_added}")
+    print(f"  Total currently assigned to another epic: {summary.currently_other_epic}")
+    print(f"  Total currently without an epic: {summary.currently_no_epic}")
+
+
+def render_result(result: AuditResult) -> None:
+    print("\nEpic membership events")
+    output_width = min(100, shutil.get_terminal_size(fallback=(100, 24)).columns)
+    for line in build_table_lines(result.events, width=output_width):
+        print(line)
+    for epic_key in result.diagnostics.resolved_epic_keys:
+        _print_summary(f"Summary for {epic_key}", result.summaries[epic_key])
+    _print_summary("Overall summary", result.overall_summary)
+
+    diagnostics = result.diagnostics
+    print("\nAudit method and limitations")
+    print(f"  Epic selector used: {diagnostics.selector}")
+    print(f"  Resolved epic keys: {', '.join(diagnostics.resolved_epic_keys)}")
+    print(f"  Audit interval: [{diagnostics.since.isoformat()}, {diagnostics.until.isoformat()}] (inclusive)")
+    print(f"  Date-only input timezone: {diagnostics.input_timezone}")
+    print(f"  Candidate JQL: {diagnostics.candidate_jql}")
+    print(f"  Candidate issue count: {diagnostics.candidate_count}")
+    print(f"  Changelog endpoint/method used: {diagnostics.changelog_method}")
+    print(f"  Every page completed successfully: {'yes' if diagnostics.every_page_complete else 'no'}")
+    print(f"  Audit data complete for accessible scope: {'yes' if diagnostics.audit_complete else 'no'}")
+    print("  Project scope: all projects accessible to the authenticated Jira account; no project restriction applied.")
+    print("  Permission limitation: inaccessible projects, issues, or secured changelog entries cannot be enumerated.")
+    print("  Current fields are execution-time snapshots, including status and current parent/epic.")
+    print("  Current relationship values marked Unknown are excluded from both current-destination counters.")
+    if diagnostics.label_selection:
+        print(
+            "  Current-label-selection limitation: only accessible Epics currently carrying the label are discovered; "
+            "Epics whose label was removed earlier are not included."
+        )
+    if diagnostics.limitations:
+        print("  Retrieval/data limitations:")
+        for limitation in diagnostics.limitations:
+            print(f"    - {limitation}")
+    else:
+        print("  Retrieval/data limitations: none reported by completed API pages.")
+
+
+def _candidate_fields(relationship_fields: RelationshipFields) -> list[str]:
+    fields = {"summary", "issuetype", "status", "parent", "updated"}
+    fields.update(field_id for field_id in relationship_fields.field_ids if field_id.startswith("customfield_"))
+    return sorted(fields)
+
+
+def run_audit(args: argparse.Namespace) -> AuditResult | None:  # pylint: disable=too-many-locals
+    until = args.until or datetime.now(ZoneInfo(args.timezone))
+    if until < args.since:
+        raise AuditError("--until must be the same as or later than --since")
+    print_resolved_interval(args, until)
+    epics = resolve_epics(args.epic, args.label)
+    print(f"Resolved epic keys: {', '.join(ref.key for ref in epics) if epics else '(none)'}")
+    if args.label and not epics:
+        print(
+            "No accessible Epics currently carry that label. Check the label and permissions; "
+            "historically labeled Epics are not discoverable after the label is removed."
+        )
+        return None
+
+    field_result: JiraFieldResult = get_jira_field_metadata()
+    relationship_fields = discover_relationship_fields(field_result.fields)
+    candidate_jql = build_candidate_jql(args.since)
+    print(f"Candidate JQL: {candidate_jql}")
+    candidate_result: JiraSearchResult = search_jira_issues_raw(candidate_jql, _candidate_fields(relationship_fields))
+    snapshots, snapshot_limitations = build_issue_snapshots(candidate_result.issues, relationship_fields)
+    id_to_key = {snapshot.issue_id: snapshot.key for snapshot in snapshots.values() if snapshot.issue_id}
+    candidate_ids = [snapshot.issue_id or snapshot.key for snapshot in snapshots.values()]
+    changelog_result: ChangelogFetchResult = fetch_complete_changelogs(candidate_ids, id_to_key)
+    events, evidence_limitations = classify_membership_events(
+        snapshots,
+        changelog_result.records_by_issue,
+        epics,
+        relationship_fields,
+        args.since,
+        until,
+    )
+    limitations = unique_messages(
+        [
+            *field_result.limitations,
+            *candidate_result.limitations,
+            *snapshot_limitations,
+            *changelog_result.limitations,
+            *evidence_limitations,
+        ]
+    )
+    every_page_complete = field_result.complete and candidate_result.complete and changelog_result.complete
+    audit_complete = every_page_complete and not snapshot_limitations and not evidence_limitations
+    epic_keys = [ref.key for ref in epics]
+    summaries, overall = summarize_events(events, epics)
+    diagnostics = AuditDiagnostics(
+        selector=f"--epic {args.epic}" if args.epic else f"--label {args.label}",
+        resolved_epic_keys=epic_keys,
+        since=args.since,
+        until=until,
+        candidate_jql=candidate_jql,
+        candidate_count=len(snapshots),
+        changelog_method=changelog_result.method,
+        every_page_complete=every_page_complete,
+        audit_complete=audit_complete,
+        input_timezone=args.timezone,
+        limitations=limitations,
+        label_selection=bool(args.label),
+    )
+    if args.verbose:
+        print(
+            f"Retrieved {candidate_result.page_count} candidate page(s) and "
+            f"{changelog_result.page_count} changelog page(s) using {changelog_result.method}."
+        )
+    return AuditResult(events, summaries, overall, diagnostics)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    try:
+        result = run_audit(args)
+        if result is None:
+            return 0
+        render_result(result)
+        if args.csv_path:
+            write_csv(result.events, args.csv_path)
+            print(f"\nCSV written to: {args.csv_path}")
+        return 0 if result.diagnostics.audit_complete else 2
+    except (AuditError, OSError, ValueError) as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/jira_metrics/jira_utils.py
+++ b/jira_metrics/jira_utils.py
@@ -1,16 +1,21 @@
 import argparse
+import json
 import os
 import time
 from collections.abc import Callable
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum
+from typing import Any
 
 import requests
 from dotenv import load_dotenv
 from gql import Client, gql
 from gql.transport.requests import RequestsHTTPTransport
 from jira import JIRA
+
+# Raw Jira JSON is intentionally dynamic only at this deserialization boundary.
+# pylint: disable=too-many-lines
 
 load_dotenv()
 
@@ -81,6 +86,368 @@ class TimeInStatusResult:
     total_seconds: float
     last_exit_timestamp: datetime | None
     open_start_timestamp: datetime | None
+
+
+@dataclass(frozen=True)
+class JiraSearchResult:
+    """Raw Jira issue search pages plus completeness diagnostics."""
+
+    issues: list[dict[str, Any]]
+    complete: bool
+    limitations: list[str] = field(default_factory=list)
+    page_count: int = 0
+
+
+@dataclass(frozen=True)
+class JiraFieldResult:
+    """Jira field metadata plus completeness diagnostics."""
+
+    fields: list[dict[str, Any]]
+    complete: bool
+    limitations: list[str] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class ChangelogFetchResult:
+    """Complete raw changelogs grouped by issue key."""
+
+    records_by_issue: dict[str, list[dict[str, Any]]]
+    method: str
+    complete: bool
+    limitations: list[str] = field(default_factory=list)
+    page_count: int = 0
+
+
+def _jira_rest_config() -> tuple[str, tuple[str, str], dict[str, str]]:
+    """Return validated Jira REST configuration without exposing its values."""
+    jira_link = os.environ.get("JIRA_LINK")
+    user_email = os.environ.get("USER_EMAIL")
+    api_key = os.environ.get("JIRA_API_KEY")
+    missing = [
+        name
+        for name, value in (("JIRA_LINK", jira_link), ("USER_EMAIL", user_email), ("JIRA_API_KEY", api_key))
+        if not value
+    ]
+    if missing:
+        raise ValueError(f"Missing required Jira environment variables: {', '.join(missing)}")
+
+    headers = {"Accept": "application/json", "Content-Type": "application/json"}
+    return jira_link.rstrip("/"), (user_email, api_key), headers
+
+
+def _request_jira_json(method, url, *, auth, headers, params=None, payload=None):  # pylint: disable=too-many-arguments
+    """Request a Jira JSON page with bounded retries and sanitized failures."""
+    request = requests.get if method == "GET" else requests.post
+    response = None
+    for attempt in range(5):
+        try:
+            kwargs = {"auth": auth, "headers": headers, "timeout": 30}
+            if params is not None:
+                kwargs["params"] = params
+            if payload is not None:
+                kwargs["json"] = payload
+            response = request(url, **kwargs)
+        except requests.exceptions.RequestException:
+            if attempt == 4:
+                return None, None, f"{method} request failed after retries"
+            time.sleep(min(2**attempt, 10))
+            continue
+
+        if response.status_code in (429, 500, 502, 503, 504) and attempt < 4:
+            time.sleep(min(2**attempt, 10))
+            continue
+        if response.status_code != 200:
+            return None, response.status_code, f"{method} request returned status {response.status_code}"
+        try:
+            return response.json(), response.status_code, None
+        except ValueError:
+            return None, response.status_code, f"{method} request returned invalid JSON"
+
+    return None, getattr(response, "status_code", None), f"{method} request failed"
+
+
+def search_jira_issues_raw(  # pylint: disable=too-many-locals,too-many-return-statements
+    jql: str, fields: list[str]
+) -> JiraSearchResult:
+    """Return all raw issues from Jira's token-paginated v3 search endpoint."""
+    jira_link, auth, headers = _jira_rest_config()
+    endpoint = f"{jira_link}/rest/api/3/search/jql"
+    issues: list[dict[str, Any]] = []
+    limitations: list[str] = []
+    next_page_token = None
+    seen_tokens: set[str] = set()
+    page_count = 0
+
+    while True:
+        params = {"jql": jql, "fields": ",".join(fields), "maxResults": 100}
+        if next_page_token:
+            params["nextPageToken"] = next_page_token
+        data, _, error = _request_jira_json("GET", endpoint, auth=auth, headers=headers, params=params)
+        if error:
+            limitations.append(f"Candidate search page {page_count + 1} failed: {error}.")
+            return JiraSearchResult(issues, False, limitations, page_count)
+        page_count += 1
+        if not isinstance(data, dict):
+            limitations.append(f"Candidate search page {page_count} had an unexpected response shape.")
+            return JiraSearchResult(issues, False, limitations, page_count)
+
+        page_issues = data.get("issues", [])
+        if not isinstance(page_issues, list):
+            limitations.append(f"Candidate search page {page_count} did not contain an issue list.")
+            return JiraSearchResult(issues, False, limitations, page_count)
+        if any(not isinstance(issue, dict) for issue in page_issues):
+            limitations.append(f"Candidate search page {page_count} contained an invalid issue entry.")
+            return JiraSearchResult(issues, False, limitations, page_count)
+        issues.extend(page_issues)
+
+        token = data.get("nextPageToken")
+        if token:
+            token = str(token)
+            if token in seen_tokens:
+                limitations.append("Candidate search returned a repeated next-page token.")
+                return JiraSearchResult(issues, False, limitations, page_count)
+            seen_tokens.add(token)
+            next_page_token = token
+            continue
+        if data.get("isLast", True):
+            return JiraSearchResult(issues, True, limitations, page_count)
+        limitations.append("Candidate search ended before Jira marked the final page.")
+        return JiraSearchResult(issues, False, limitations, page_count)
+
+
+def get_jira_field_metadata() -> JiraFieldResult:
+    """Fetch raw Jira field metadata used to discover relationship field IDs."""
+    jira_link, auth, headers = _jira_rest_config()
+    data, _, error = _request_jira_json("GET", f"{jira_link}/rest/api/3/field", auth=auth, headers=headers)
+    if error:
+        return JiraFieldResult([], False, [f"Jira field metadata retrieval failed: {error}."])
+    if not isinstance(data, list):
+        return JiraFieldResult([], False, ["Jira field metadata had an unexpected response shape."])
+    if any(not isinstance(item, dict) for item in data):
+        return JiraFieldResult(
+            [item for item in data if isinstance(item, dict)],
+            False,
+            ["Jira field metadata contained an invalid field entry."],
+        )
+    return JiraFieldResult(data, True)
+
+
+def _history_identity(history: dict[str, Any]) -> str:
+    """Return a deterministic identity for exact raw-history deduplication."""
+    return json.dumps(history, sort_keys=True, separators=(",", ":"), default=str)
+
+
+def _merge_history_records(target: list[dict[str, Any]], additions: list[dict[str, Any]]) -> None:
+    identities = {_history_identity(record) for record in target}
+    for record in additions:
+        identity = _history_identity(record)
+        if identity not in identities:
+            target.append(record)
+            identities.add(identity)
+
+
+def _validate_changelog_page_range(
+    data: dict[str, Any], requested_start: int, value_count: int
+) -> tuple[int, str | None]:
+    """Validate Jira pagination metadata and return the proven page end."""
+    response_start = data.get("startAt")
+    if not isinstance(response_start, int) or isinstance(response_start, bool) or response_start != requested_start:
+        returned_start = response_start if isinstance(response_start, int) else "missing or invalid"
+        return (
+            requested_start,
+            f"requested startAt {requested_start} but Jira returned {returned_start}; "
+            "pagination did not make reliable forward progress",
+        )
+
+    total = data.get("total")
+    if total is not None and (not isinstance(total, int) or isinstance(total, bool) or total < 0):
+        return requested_start, "returned invalid total pagination metadata"
+
+    is_last = data.get("isLast")
+    if is_last is not None and not isinstance(is_last, bool):
+        return requested_start, "returned invalid isLast pagination metadata"
+
+    page_end = response_start + value_count
+    if isinstance(total, int):
+        terminal_conflict = (is_last is True and page_end != total) or (is_last is False and page_end >= total)
+        if page_end > total or terminal_conflict:
+            return (
+                requested_start,
+                "returned contradictory pagination metadata: "
+                f"isLast={is_last}, page range {response_start}:{page_end}, total={total}",
+            )
+    return page_end, None
+
+
+def _fetch_issue_changelog(  # pylint: disable=too-many-locals,too-many-return-statements
+    issue_key: str, jira_link, auth, headers
+):
+    endpoint = f"{jira_link}/rest/api/3/issue/{issue_key}/changelog"
+    records: list[dict[str, Any]] = []
+    start_at = 0
+    page_count = 0
+
+    while True:
+        params = {"startAt": start_at, "maxResults": 100}
+        data, _, error = _request_jira_json("GET", endpoint, auth=auth, headers=headers, params=params)
+        if error:
+            return records, False, page_count, f"Changelog fallback for {issue_key} failed: {error}."
+        page_count += 1
+        if not isinstance(data, dict) or not isinstance(data.get("values", []), list):
+            return records, False, page_count, f"Changelog fallback for {issue_key} had an unexpected response shape."
+        raw_values = data.get("values", [])
+        if any(not isinstance(item, dict) for item in raw_values):
+            return records, False, page_count, f"Changelog fallback for {issue_key} had an invalid history entry."
+        values = list(raw_values)
+        _merge_history_records(records, values)
+
+        page_end, pagination_error = _validate_changelog_page_range(data, start_at, len(values))
+        if pagination_error:
+            return records, False, page_count, f"Changelog fallback for {issue_key} {pagination_error}."
+        total = data.get("total")
+        is_last = data.get("isLast")
+        if is_last is True:
+            return records, True, page_count, None
+        if isinstance(total, int) and page_end == total:
+            return records, True, page_count, None
+        if not values:
+            return (
+                records,
+                False,
+                page_count,
+                f"Changelog fallback for {issue_key} ended before the final page and made no forward progress.",
+            )
+        if is_last is None and not isinstance(total, int):
+            return (
+                records,
+                False,
+                page_count,
+                f"Changelog fallback for {issue_key} did not provide reliable pagination termination.",
+            )
+        start_at = page_end
+
+
+def _bulk_page_records(data, id_to_key):
+    """Extract issue-keyed histories from one bulk changelog page."""
+    containers = data.get("issueChangeLogs", []) if isinstance(data, dict) else []
+    if not isinstance(containers, list):
+        return None
+    page_records: dict[str, list[dict[str, Any]]] = {}
+    confirmed: set[str] = set()
+    for container in containers:
+        if not isinstance(container, dict):
+            return None
+        raw_identity = container.get("issueId") or container.get("issueKey")
+        if raw_identity is None:
+            return None
+        identity = str(raw_identity)
+        issue_key = id_to_key.get(identity, identity)
+        histories = container.get("changeHistories", [])
+        if not isinstance(histories, list) or any(not isinstance(item, dict) for item in histories):
+            return None
+        confirmed.add(issue_key)
+        page_records.setdefault(issue_key, []).extend(histories)
+    return page_records, confirmed
+
+
+def fetch_complete_changelogs(  # pylint: disable=too-many-locals,too-many-branches,too-many-statements
+    issue_ids_or_keys: list[str], id_to_key: dict[str, str] | None = None
+) -> ChangelogFetchResult:
+    """Fetch complete raw changelogs using bulk pages with per-issue fallback."""
+    if not issue_ids_or_keys:
+        return ChangelogFetchResult({}, "bulk", True)
+
+    jira_link, auth, headers = _jira_rest_config()
+    endpoint = f"{jira_link}/rest/api/3/changelog/bulkfetch"
+    lookup = dict(id_to_key or {})
+    requested_keys = {lookup.get(value, value) for value in issue_ids_or_keys}
+    records_by_issue = {key: [] for key in requested_keys}
+    limitations: list[str] = []
+    methods: set[str] = set()
+    complete = True
+    page_count = 0
+    bulk_supported = True
+
+    for offset in range(0, len(issue_ids_or_keys), 1000):
+        batch = issue_ids_or_keys[offset : offset + 1000]
+        batch_keys = {lookup.get(value, value) for value in batch}
+        confirmed: set[str] = set()
+        batch_failed = False
+        next_page_token = None
+        seen_tokens: set[str] = set()
+
+        if bulk_supported:
+            while True:
+                payload = {"issueIdsOrKeys": batch, "maxResults": 1000}
+                if next_page_token:
+                    payload["nextPageToken"] = next_page_token
+                data, status, error = _request_jira_json("POST", endpoint, auth=auth, headers=headers, payload=payload)
+                if error:
+                    if status in (400, 404, 405):
+                        bulk_supported = False
+                        limitations.append(
+                            "Bulk changelog retrieval is unavailable; complete per-issue fallback was used."
+                        )
+                    else:
+                        complete = False
+                        limitations.append(f"Bulk changelog page failed: {error}; per-issue fallback was attempted.")
+                    batch_failed = True
+                    break
+                methods.add("bulk")
+                page_count += 1
+                extracted = _bulk_page_records(data, lookup)
+                if extracted is None:
+                    complete = False
+                    limitations.append(
+                        "Bulk changelog page had an unexpected response shape; per-issue fallback was attempted."
+                    )
+                    batch_failed = True
+                    break
+                page_records, page_confirmed = extracted
+                confirmed.update(page_confirmed)
+                for issue_key, histories in page_records.items():
+                    records_by_issue.setdefault(issue_key, [])
+                    _merge_history_records(records_by_issue[issue_key], histories)
+
+                token = data.get("nextPageToken") if isinstance(data, dict) else None
+                if not token:
+                    break
+                token = str(token)
+                if token in seen_tokens:
+                    complete = False
+                    limitations.append("Bulk changelog retrieval returned a repeated next-page token.")
+                    batch_failed = True
+                    break
+                seen_tokens.add(token)
+                next_page_token = token
+        else:
+            batch_failed = True
+
+        fallback_keys = batch_keys if batch_failed else batch_keys - confirmed
+        if fallback_keys and not batch_failed:
+            limitations.append(
+                "Bulk changelog response omitted requested issues; complete per-issue fallback was used for those issues."
+            )
+        for issue_key in sorted(fallback_keys):
+            methods.add("per-issue fallback")
+            histories, issue_complete, fallback_pages, limitation = _fetch_issue_changelog(
+                issue_key, jira_link, auth, headers
+            )
+            page_count += fallback_pages
+            records_by_issue.setdefault(issue_key, [])
+            _merge_history_records(records_by_issue[issue_key], histories)
+            if not issue_complete:
+                complete = False
+                if limitation:
+                    limitations.append(limitation)
+
+    if methods == {"bulk"}:
+        method = "bulk"
+    elif methods == {"per-issue fallback"}:
+        method = "per-issue fallback"
+    else:
+        method = "mixed bulk and per-issue fallback"
+    return ChangelogFetchResult(records_by_issue, method, complete, limitations, page_count)
 
 
 def get_common_parser():

--- a/jira_metrics/tests/test_epic_membership_history.py
+++ b/jira_metrics/tests/test_epic_membership_history.py
@@ -1,0 +1,582 @@
+"""Tests for the changelog-evidence epic membership audit."""
+
+import argparse
+import csv
+import io
+import os
+import sys
+import tempfile
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+# pylint: disable=wrong-import-position,import-error
+import epic_membership_history as audit
+from jira_utils import ChangelogFetchResult, JiraFieldResult, JiraSearchResult
+
+
+SINCE = datetime(2024, 1, 1, tzinfo=timezone.utc)
+UNTIL = datetime(2024, 1, 31, 23, 59, tzinfo=timezone.utc)
+EPIC_A = audit.EpicRef("EPIC-1", "10001")
+EPIC_B = audit.EpicRef("EPIC-2", "10002")
+
+
+def snapshot(key="WORK-1", current_parent="EPIC-1", current_state="known"):
+    return audit.IssueSnapshot(
+        key=key,
+        issue_id=f"id-{key}",
+        summary=f"Summary for {key}",
+        issue_type="Story",
+        status="In Progress",
+        updated="2024-02-10T00:00:00+00:00",
+        current_parent=current_parent,
+        current_parent_state=current_state,
+    )
+
+
+def history(
+    history_id,
+    created,
+    previous,
+    new,
+    *,
+    field_name="Parent",
+    field_id="parent",
+    previous_id=None,
+    new_id=None,
+):
+    return {
+        "id": history_id,
+        "created": created,
+        "author": {"displayName": "Example Actor", "accountId": "account-1"},
+        "items": [
+            {
+                "field": field_name,
+                "fieldId": field_id,
+                "from": previous_id,
+                "fromString": previous,
+                "to": new_id,
+                "toString": new,
+            }
+        ],
+    }
+
+
+def registry(metadata=None):
+    return audit.discover_relationship_fields(metadata or [])
+
+
+def classify(histories, *, issues=None, epics=None, fields=None):
+    snapshots = issues or {"WORK-1": snapshot()}
+    records = {key: histories if key == "WORK-1" else [] for key in snapshots}
+    return audit.classify_membership_events(
+        snapshots,
+        records,
+        epics or [EPIC_A],
+        fields or registry(),
+        SINCE,
+        UNTIL,
+    )
+
+
+class TestCliAndSelection(unittest.TestCase):
+    def test_parse_args_requires_exactly_one_epic_selector(self):
+        with redirect_stderr(io.StringIO()), self.assertRaises(SystemExit):
+            audit.parse_args(["--since", "2024-01-01T00:00:00Z"])
+
+    def test_parse_args_rejects_epic_and_label_together(self):
+        with redirect_stderr(io.StringIO()), self.assertRaises(SystemExit):
+            audit.parse_args(["--epic", "EPIC-1", "--label", "quarter", "--since", "2024-01-01T00:00:00Z"])
+
+    def test_parse_aware_timestamp_rejects_naive_value(self):
+        with self.assertRaises(argparse.ArgumentTypeError):
+            audit.parse_aware_timestamp("2024-01-01T00:00:00")
+
+    def test_date_only_since_defaults_to_denver_and_observes_dst(self):
+        summer = audit.parse_args(["--epic", "EPIC-1", "--since", "2026-07-06"])
+        winter = audit.parse_args(["--epic", "EPIC-1", "--since", "2026-01-06"])
+
+        self.assertEqual(summer.timezone, "America/Denver")
+        self.assertEqual(summer.since.isoformat(), "2026-07-06T00:00:00-06:00")
+        self.assertEqual(winter.since.isoformat(), "2026-01-06T00:00:00-07:00")
+
+    def test_date_only_until_means_end_of_day_in_selected_timezone(self):
+        args = audit.parse_args(
+            [
+                "--epic",
+                "EPIC-1",
+                "--since",
+                "2026-07-06",
+                "--until",
+                "2026-07-07",
+                "--timezone",
+                "America/Los_Angeles",
+            ]
+        )
+
+        self.assertEqual(args.since.isoformat(), "2026-07-06T00:00:00-07:00")
+        self.assertEqual(args.until.isoformat(), "2026-07-07T23:59:59.999999-07:00")
+
+    def test_explicit_offset_is_preserved_and_naive_clock_time_is_rejected(self):
+        args = audit.parse_args(["--epic", "EPIC-1", "--since", "2026-07-06T00:00:00Z", "--timezone", "America/Denver"])
+        self.assertEqual(args.since.isoformat(), "2026-07-06T00:00:00+00:00")
+
+        with redirect_stderr(io.StringIO()), self.assertRaises(SystemExit):
+            audit.parse_args(["--epic", "EPIC-1", "--since", "2026-07-06T12:00:00"])
+
+    def test_invalid_timezone_is_rejected(self):
+        with redirect_stderr(io.StringIO()), self.assertRaises(SystemExit):
+            audit.parse_args(["--epic", "EPIC-1", "--since", "2026-07-06", "--timezone", "Not/A_Timezone"])
+
+    def test_resolved_interval_is_confirmed_before_audit(self):
+        args = audit.parse_args(["--epic", "EPIC-1", "--since", "2026-07-06", "--until", "2026-07-07"])
+        output = io.StringIO()
+
+        with redirect_stdout(output):
+            audit.print_resolved_interval(args, args.until)
+
+        rendered = output.getvalue()
+        self.assertIn("Resolved audit interval:", rendered)
+        self.assertIn("--since 2026-07-06 -> 2026-07-06T00:00:00-06:00", rendered)
+        self.assertIn("--until 2026-07-07 -> 2026-07-07T23:59:59.999999-06:00", rendered)
+        self.assertIn("Date-only timezone: America/Denver", rendered)
+        self.assertIn("Boundaries: inclusive", rendered)
+
+    def test_interval_rejects_until_before_since(self):
+        with redirect_stderr(io.StringIO()), self.assertRaises(SystemExit):
+            audit.parse_args(
+                [
+                    "--epic",
+                    "EPIC-1",
+                    "--since",
+                    "2024-01-02T00:00:00Z",
+                    "--until",
+                    "2024-01-01T00:00:00Z",
+                ]
+            )
+
+    @patch("epic_membership_history.search_jira_issues_raw")
+    def test_epic_selector_resolves_only_supplied_epic(self, mock_search):
+        mock_search.return_value = JiraSearchResult(
+            [
+                {"id": "10001", "key": "EPIC-1", "fields": {"issuetype": {"name": "Epic"}}},
+                {"id": "10002", "key": "EPIC-2", "fields": {"issuetype": {"name": "Epic"}}},
+            ],
+            True,
+        )
+
+        result = audit.resolve_epics("EPIC-1", None)
+
+        self.assertEqual(result, [EPIC_A])
+        self.assertEqual(mock_search.call_args.args[0], 'key = "EPIC-1" AND issuetype = Epic')
+
+    @patch("epic_membership_history.search_jira_issues_raw")
+    def test_label_selector_resolves_every_current_matching_epic_and_excludes_non_epics(self, mock_search):
+        mock_search.return_value = JiraSearchResult(
+            [
+                {"id": "10002", "key": "EPIC-2", "fields": {"issuetype": {"name": "Epic"}}},
+                {"id": "20001", "key": "WORK-1", "fields": {"issuetype": {"name": "Story"}}},
+                {"id": "10001", "key": "EPIC-1", "fields": {"issuetype": {"name": "Epic"}}},
+            ],
+            True,
+        )
+
+        result = audit.resolve_epics(None, "current-label")
+
+        self.assertEqual(result, [EPIC_A, EPIC_B])
+        self.assertIn("issuetype = Epic", mock_search.call_args.args[0])
+        self.assertIn('labels = "current-label"', mock_search.call_args.args[0])
+
+    @patch("epic_membership_history.resolve_epics", return_value=[])
+    def test_label_selector_with_no_epics_exits_cleanly_with_actionable_message(self, _mock_resolve):
+        output = io.StringIO()
+        with redirect_stdout(output):
+            status = audit.main(["--label", "missing", "--since", "2024-01-01T00:00:00Z"])
+
+        self.assertEqual(status, 0)
+        self.assertIn("No accessible Epics currently carry that label", output.getvalue())
+        self.assertIn("historically labeled", output.getvalue())
+
+
+class TestCandidateAndRelationshipDiscovery(unittest.TestCase):
+    def test_candidate_jql_uses_updated_lower_bound_not_created_or_upper_bound(self):
+        jql = audit.build_candidate_jql(datetime(2024, 3, 10, 12, tzinfo=timezone.utc))
+
+        self.assertIn('updated >= "2024-03-08 00:00"', jql)
+        self.assertNotIn("created", jql.casefold())
+        self.assertEqual(jql.casefold().count("updated"), 2)  # predicate plus ordering only
+        self.assertNotIn("<=", jql)
+
+    def test_discovered_legacy_field_id_is_recognized(self):
+        fields = registry([{"id": "customfield_12345", "name": "Epic Link"}])
+
+        self.assertTrue(fields.recognizes("Legacy relationship", "customfield_12345"))
+
+    def test_absent_requested_relationship_fields_mean_no_current_epic(self):
+        raw_issues = [{"id": "1", "key": "WORK-1", "fields": {"summary": "No parent"}}]
+
+        snapshots, limitations = audit.build_issue_snapshots(raw_issues, registry())
+
+        self.assertEqual(snapshots["WORK-1"].current_parent_state, "empty")
+        self.assertIsNone(snapshots["WORK-1"].current_parent)
+        self.assertEqual(limitations, [])
+
+    def test_unavailable_or_conflicting_current_relationship_is_unknown(self):
+        raw_issues = [
+            {"id": "1", "key": "WORK-1"},
+            {
+                "id": "2",
+                "key": "WORK-2",
+                "fields": {"parent": {"key": "EPIC-1"}, "issueParentAssociation": "EPIC-2"},
+            },
+        ]
+
+        snapshots, limitations = audit.build_issue_snapshots(raw_issues, registry())
+
+        self.assertEqual(snapshots["WORK-1"].current_parent_state, "unknown")
+        self.assertEqual(snapshots["WORK-2"].current_parent_state, "unknown")
+        self.assertEqual(len(limitations), 2)
+
+
+class TestClassification(unittest.TestCase):
+    def test_interval_includes_exact_since_and_until_boundaries(self):
+        records = [
+            history("h-1", SINCE.isoformat(), None, "EPIC-1"),
+            history("h-2", UNTIL.isoformat(), "EPIC-1", None),
+        ]
+
+        events, _ = classify(records)
+
+        self.assertEqual([event.event_type for event in events], ["added", "removed"])
+
+    def test_old_issue_removed_after_since_is_reported(self):
+        raw_issue = {
+            "id": "1",
+            "key": "WORK-1",
+            "fields": {
+                "created": "2010-01-01T00:00:00Z",
+                "updated": "2024-02-10T00:00:00Z",
+                "parent": None,
+            },
+        }
+        snapshots, _ = audit.build_issue_snapshots([raw_issue], registry())
+
+        events, _ = classify(
+            [history("h-1", "2024-01-02T00:00:00Z", "EPIC-1", None)],
+            issues=snapshots,
+        )
+
+        self.assertEqual([event.event_type for event in events], ["removed"])
+
+    def test_relationship_name_and_discovered_id_variants(self):
+        fields = registry([{"id": "customfield_12345", "name": "Epic Link"}])
+        variants = [
+            ("Parent", "parent"),
+            ("epic link", ""),
+            ("IssueParentAssociation", "issueparentassociation"),
+            ("Legacy relationship", "customfield_12345"),
+        ]
+        for field_name, field_id in variants:
+            with self.subTest(field_name=field_name, field_id=field_id):
+                records = [
+                    history(
+                        f"h-{field_name}",
+                        "2024-01-02T00:00:00Z",
+                        None,
+                        "EPIC-1",
+                        field_name=field_name,
+                        field_id=field_id,
+                    )
+                ]
+                events, _ = classify(records, fields=fields)
+                self.assertEqual([event.event_type for event in events], ["added"])
+
+    def test_add_move_remove_and_move_out_classifications(self):
+        cases = [
+            (None, "EPIC-1", "added"),
+            ("OTHER-1", "EPIC-1", "moved_in"),
+            ("EPIC-1", None, "removed"),
+            ("EPIC-1", "OTHER-1", "moved_out"),
+        ]
+        for previous, new, expected in cases:
+            with self.subTest(expected=expected):
+                events, _ = classify([history("h-1", "2024-01-02T00:00:00Z", previous, new)])
+                self.assertEqual([event.event_type for event in events], [expected])
+
+    def test_removal_followed_by_entry_is_re_added_and_marks_outbound(self):
+        records = [
+            history("h-0", "2023-12-31T00:00:00Z", "EPIC-1", None),
+            history("h-1", "2024-01-02T00:00:00Z", None, "EPIC-1"),
+            history("h-2", "2024-01-03T00:00:00Z", "EPIC-1", None),
+            history("h-3", "2024-01-04T00:00:00Z", None, "EPIC-1"),
+        ]
+
+        events, _ = classify(records)
+
+        self.assertEqual([event.event_type for event in events], ["re_added", "removed", "re_added"])
+        self.assertTrue(events[1].later_re_added)
+
+    def test_repeated_removals_retained_but_exact_duplicates_removed(self):
+        first = history("h-1", "2024-01-02T00:00:00Z", "EPIC-1", None)
+        records = [
+            first,
+            first.copy(),
+            history("h-2", "2024-01-03T00:00:00Z", None, "EPIC-1"),
+            history("h-3", "2024-01-04T00:00:00Z", "EPIC-1", None),
+        ]
+
+        events, _ = classify(records)
+
+        self.assertEqual([event.event_type for event in events].count("removed"), 2)
+        self.assertEqual(len(events), 3)
+
+    def test_currently_assigned_issue_without_removal_evidence_is_not_reported(self):
+        events, _ = classify([])
+        self.assertEqual(events, [])
+
+    def test_move_between_selected_epics_emits_both_perspectives(self):
+        events, _ = classify(
+            [history("h-1", "2024-01-02T00:00:00Z", "EPIC-1", "EPIC-2")],
+            epics=[EPIC_A, EPIC_B],
+        )
+
+        self.assertEqual(
+            {(event.epic_key, event.event_type) for event in events},
+            {("EPIC-1", "moved_out"), ("EPIC-2", "moved_in")},
+        )
+        summaries, overall = audit.summarize_events(events, [EPIC_A, EPIC_B])
+        self.assertEqual(summaries["EPIC-1"].moves_out, 1)
+        self.assertEqual(summaries["EPIC-2"].moves_in, 1)
+        self.assertEqual(overall.unique_issues, 1)
+
+    def test_author_and_raw_changelog_evidence_are_retained(self):
+        events, _ = classify(
+            [
+                history(
+                    "h-1",
+                    "2024-01-02T00:00:00Z",
+                    None,
+                    "EPIC-1",
+                    new_id="10001",
+                )
+            ]
+        )
+
+        event = events[0]
+        self.assertEqual(event.evidence.actor_display_name, "Example Actor")
+        self.assertEqual(event.evidence.actor_account_id, "account-1")
+        self.assertIn('"to":"10001"', event.evidence.raw_evidence)
+        self.assertIn('"toString":"EPIC-1"', event.evidence.raw_evidence)
+
+    def test_display_summary_mention_does_not_match_selected_epic(self):
+        events, _ = classify(
+            [
+                history(
+                    "h-1",
+                    "2024-01-02T00:00:00Z",
+                    "OTHER-9 Summary mentions EPIC-1",
+                    None,
+                )
+            ]
+        )
+
+        self.assertEqual(events, [])
+
+    def test_contradictory_raw_id_prevents_display_string_match(self):
+        events, _ = classify(
+            [
+                history(
+                    "h-1",
+                    "2024-01-02T00:00:00Z",
+                    "EPIC-1 Summary text",
+                    None,
+                    previous_id="99999",
+                )
+            ]
+        )
+
+        self.assertEqual(events, [])
+
+
+class TestReportingAndOrchestration(unittest.TestCase):
+    def _eventful_result(self):
+        issues = {
+            "WORK-1": snapshot("WORK-1", current_parent="EPIC-1"),
+            "WORK-2": snapshot("WORK-2", current_parent="OTHER-1"),
+        }
+        histories = {
+            "WORK-1": [
+                history("h-1", "2024-01-02T00:00:00Z", None, "EPIC-1"),
+                history("h-2", "2024-01-03T00:00:00Z", "EPIC-1", None),
+                history("h-3", "2024-01-04T00:00:00Z", None, "EPIC-1"),
+            ],
+            "WORK-2": [
+                history("h-4", "2024-01-05T00:00:00Z", "OTHER-1", "EPIC-1"),
+                history("h-5", "2024-01-06T00:00:00Z", "EPIC-1", "OTHER-1"),
+            ],
+        }
+        events, _ = audit.classify_membership_events(issues, histories, [EPIC_A], registry(), SINCE, UNTIL)
+        summaries, overall = audit.summarize_events(events, [EPIC_A])
+        diagnostics = audit.AuditDiagnostics(
+            selector="--epic EPIC-1",
+            resolved_epic_keys=["EPIC-1"],
+            since=SINCE,
+            until=UNTIL,
+            candidate_jql='updated >= "2023-12-30 00:00" ORDER BY updated ASC',
+            candidate_count=2,
+            changelog_method="bulk",
+            every_page_complete=True,
+            audit_complete=True,
+        )
+        return audit.AuditResult(events, summaries, overall, diagnostics)
+
+    def test_event_rows_shared_by_table_and_csv_and_chronological(self):
+        result = self._eventful_result()
+        rows = [audit.event_to_row(event) for event in result.events]
+        self.assertEqual(list(rows[0]), list(audit.EVENT_COLUMNS))
+        self.assertEqual([row["Event timestamp"] for row in rows], sorted(row["Event timestamp"] for row in rows))
+        table_lines = audit.build_table_lines(result.events, width=80)
+        table = "\n".join(table_lines)
+        for column in audit.EVENT_COLUMNS:
+            self.assertIn(column, table)
+        self.assertTrue(all(len(line) <= 80 for line in table_lines))
+        self.assertIn("Event 1 of", table)
+
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "events.csv"
+            audit.write_csv(result.events, path)
+            with path.open(encoding="utf-8", newline="") as source:
+                csv_rows = list(csv.DictReader(source))
+        self.assertEqual(csv_rows, rows)
+
+    def test_duplicate_diagnostic_messages_are_retained_once(self):
+        message = "Complete per-issue fallback was used."
+
+        self.assertEqual(audit.unique_messages([message, "Different note.", message]), [message, "Different note."])
+
+    def test_all_per_epic_and_overall_summary_counts(self):
+        result = self._eventful_result()
+        expected = audit.SummaryCounts(
+            unique_issues=2,
+            additions=1,
+            removals=1,
+            moves_in=1,
+            moves_out=1,
+            unique_outbound_issues=2,
+            later_re_added=1,
+            currently_other_epic=1,
+            currently_no_epic=0,
+        )
+        self.assertEqual(result.summaries["EPIC-1"], expected)
+        self.assertEqual(result.overall_summary, expected)
+
+    def test_zero_event_report_keeps_summaries_and_method_fields(self):
+        empty = audit.SummaryCounts(0, 0, 0, 0, 0, 0, 0, 0, 0)
+        diagnostics = audit.AuditDiagnostics(
+            selector="--label example",
+            resolved_epic_keys=["EPIC-1"],
+            since=SINCE,
+            until=UNTIL,
+            candidate_jql="updated >= boundary",
+            candidate_count=0,
+            changelog_method="bulk",
+            every_page_complete=True,
+            audit_complete=True,
+            label_selection=True,
+        )
+        result = audit.AuditResult([], {"EPIC-1": empty}, empty, diagnostics)
+        output = io.StringIO()
+
+        with redirect_stdout(output):
+            audit.render_result(result)
+
+        rendered = output.getvalue()
+        self.assertIn("No epic membership changes", rendered)
+        self.assertIn("Total additions: 0", rendered)
+        self.assertIn("Epic selector used: --label example", rendered)
+        self.assertIn("Resolved epic keys: EPIC-1", rendered)
+        self.assertIn("Audit interval:", rendered)
+        self.assertIn("Date-only input timezone: America/Denver", rendered)
+        self.assertIn("Candidate JQL:", rendered)
+        self.assertIn("Candidate issue count: 0", rendered)
+        self.assertIn("Changelog endpoint/method used: bulk", rendered)
+        self.assertIn("Every page completed successfully: yes", rendered)
+        self.assertIn("Audit data complete for accessible scope: yes", rendered)
+        self.assertIn("Current-label-selection limitation", rendered)
+
+    @patch("epic_membership_history.fetch_complete_changelogs")
+    @patch("epic_membership_history.search_jira_issues_raw")
+    @patch("epic_membership_history.get_jira_field_metadata")
+    @patch("epic_membership_history.resolve_epics")
+    def test_partial_api_failure_is_limitation_and_nonzero_status(
+        self, mock_resolve, mock_metadata, mock_search, mock_changelogs
+    ):
+        mock_resolve.return_value = [EPIC_A]
+        mock_metadata.return_value = JiraFieldResult([], True)
+        mock_search.return_value = JiraSearchResult([], False, ["candidate page failed"], 1)
+        mock_changelogs.return_value = ChangelogFetchResult({}, "bulk", True)
+        output = io.StringIO()
+
+        with redirect_stdout(output):
+            status = audit.main(["--epic", "EPIC-1", "--since", "2024-01-01T00:00:00Z"])
+
+        self.assertEqual(status, 2)
+        self.assertIn("Every page completed successfully: no", output.getvalue())
+        self.assertIn("candidate page failed", output.getvalue())
+
+    def test_unknown_current_parent_excluded_from_destination_counters(self):
+        issues = {"WORK-1": snapshot(current_parent=None, current_state="unknown")}
+        events, _ = classify(
+            [history("h-1", "2024-01-02T00:00:00Z", "EPIC-1", None)],
+            issues=issues,
+        )
+        summaries, _ = audit.summarize_events(events, [EPIC_A])
+
+        self.assertEqual(summaries["EPIC-1"].currently_other_epic, 0)
+        self.assertEqual(summaries["EPIC-1"].currently_no_epic, 0)
+
+    def test_overall_current_other_deduplicates_any_qualifying_epic_perspective(self):
+        issue = snapshot(current_parent="EPIC-2")
+        evidence_a, _ = audit.normalize_changelog_records(
+            "WORK-1",
+            [history("h-1", "2024-01-02T00:00:00Z", "EPIC-1", "EPIC-2")],
+            registry(),
+        )
+        evidence_b, _ = audit.normalize_changelog_records(
+            "WORK-1",
+            [history("h-2", "2024-01-03T00:00:00Z", "EPIC-2", None)],
+            registry(),
+        )
+        events = [
+            audit.MembershipEvent("EPIC-1", issue, "moved_out", evidence_a[0], "EPIC-1", "EPIC-2"),
+            audit.MembershipEvent("EPIC-2", issue, "removed", evidence_b[0], "EPIC-2", "(none)"),
+        ]
+
+        _, overall = audit.summarize_events(events, [EPIC_A, EPIC_B])
+
+        self.assertEqual(overall.unique_outbound_issues, 1)
+        self.assertEqual(overall.currently_other_epic, 1)
+
+    @patch("epic_membership_history.fetch_complete_changelogs")
+    @patch("epic_membership_history.search_jira_issues_raw")
+    @patch("epic_membership_history.get_jira_field_metadata")
+    @patch("epic_membership_history.resolve_epics")
+    def test_verbose_output_never_contains_api_token(self, mock_resolve, mock_metadata, mock_search, mock_changelogs):
+        mock_resolve.return_value = [EPIC_A]
+        mock_metadata.return_value = JiraFieldResult([], True)
+        mock_search.return_value = JiraSearchResult([], True, page_count=2)
+        mock_changelogs.return_value = ChangelogFetchResult({}, "bulk", True, page_count=3)
+        output = io.StringIO()
+        with patch.dict(os.environ, {"JIRA_API_KEY": "highly-secret-token"}, clear=False), redirect_stdout(output):
+            status = audit.main(["--epic", "EPIC-1", "--since", "2024-01-01T00:00:00Z", "--verbose"])
+
+        self.assertEqual(status, 0)
+        self.assertNotIn("highly-secret-token", output.getvalue())
+        self.assertIn("2 candidate page(s)", output.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/jira_metrics/tests/test_epic_membership_history.py
+++ b/jira_metrics/tests/test_epic_membership_history.py
@@ -8,6 +8,7 @@ import sys
 import tempfile
 import unittest
 from contextlib import redirect_stderr, redirect_stdout
+from dataclasses import replace
 from datetime import datetime, timezone
 from pathlib import Path
 from unittest.mock import patch
@@ -333,6 +334,18 @@ class TestClassification(unittest.TestCase):
         self.assertEqual([event.event_type for event in events].count("removed"), 2)
         self.assertEqual(len(events), 3)
 
+    def test_same_timestamp_histories_sort_numeric_ids_numerically(self):
+        timestamp = "2024-01-02T00:00:00Z"
+        records = [
+            history("10", timestamp, "EPIC-1", None),
+            history("2", timestamp, None, "EPIC-1"),
+        ]
+
+        events, _ = classify(records)
+
+        self.assertEqual([event.evidence.history_id for event in events], ["2", "10"])
+        self.assertEqual([event.event_type for event in events], ["added", "removed"])
+
     def test_currently_assigned_issue_without_removal_evidence_is_not_reported(self):
         events, _ = classify([])
         self.assertEqual(events, [])
@@ -456,6 +469,20 @@ class TestReportingAndOrchestration(unittest.TestCase):
         message = "Complete per-issue fallback was used."
 
         self.assertEqual(audit.unique_messages([message, "Different note.", message]), [message, "Different note."])
+
+    def test_csv_prefixes_formula_like_untrusted_jira_text(self):
+        result = self._eventful_result()
+        unsafe_issue = replace(result.events[0].issue, summary='=HYPERLINK("https://example.invalid")')
+        unsafe_event = replace(result.events[0], issue=unsafe_issue)
+
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "events.csv"
+            audit.write_csv([unsafe_event], path)
+            with path.open(encoding="utf-8", newline="") as source:
+                csv_row = next(csv.DictReader(source))
+
+        self.assertEqual(audit.event_to_row(unsafe_event)["Issue summary"][0], "=")
+        self.assertTrue(csv_row["Issue summary"].startswith("'="))
 
     def test_all_per_epic_and_overall_summary_counts(self):
         result = self._eventful_result()

--- a/jira_metrics/tests/test_jira_utils.py
+++ b/jira_metrics/tests/test_jira_utils.py
@@ -12,19 +12,38 @@ from jira_utils import (
     SimpleNamespace,
     calculate_total_time_in_status,
     convert_raw_issue_to_simple_object,
+    fetch_complete_changelogs,
     get_completion_statuses,
     get_excluded_statuses,
     get_issue_created_month_key,
+    get_jira_field_metadata,
     get_project_key,
     get_status_transitions_chronological,
     get_team_or_project_unknown,
     is_month_key_in_date_range,
     month_key_from_jira_datetime,
     parse_jira_datetime,
+    search_jira_issues_raw,
 )
 
 
 TEAM_FIELD_ID = "10075"
+REST_ENV = {
+    "JIRA_LINK": "https://jira.example.test",
+    "USER_EMAIL": "user@example.test",
+    "JIRA_API_KEY": "test-token",
+}
+
+
+class FakeResponse:
+    def __init__(self, status_code, payload):
+        self.status_code = status_code
+        self._payload = payload
+
+    def json(self):
+        if isinstance(self._payload, ValueError):
+            raise self._payload
+        return self._payload
 
 
 def create_changelog_entry(created, from_status, to_status):
@@ -236,3 +255,236 @@ class TestStatusTransitionHelpers(unittest.TestCase):
         self.assertEqual(result.completed_intervals, 0)
         self.assertEqual(result.total_seconds, 0)
         self.assertEqual(result.open_start_timestamp.strftime("%Y-%m-%d %H:%M"), "2024-01-03 09:00")
+
+
+class TestRawJiraRetrieval(unittest.TestCase):
+    @patch.dict(os.environ, REST_ENV, clear=False)
+    @patch("jira_utils.requests.get")
+    def test_search_jira_issues_raw_paginates_next_page_tokens(self, mock_get):
+        mock_get.side_effect = [
+            FakeResponse(200, {"issues": [{"id": "1", "key": "A-1"}], "nextPageToken": "next-1"}),
+            FakeResponse(200, {"issues": [], "nextPageToken": "next-2"}),
+            FakeResponse(200, {"issues": [{"id": "2", "key": "A-2"}], "isLast": True}),
+        ]
+
+        result = search_jira_issues_raw("updated >= '2024-01-01'", ["summary"])
+
+        self.assertTrue(result.complete)
+        self.assertEqual([issue["key"] for issue in result.issues], ["A-1", "A-2"])
+        self.assertEqual(result.page_count, 3)
+        self.assertNotIn("nextPageToken", mock_get.call_args_list[0].kwargs["params"])
+        self.assertEqual(mock_get.call_args_list[1].kwargs["params"]["nextPageToken"], "next-1")
+        self.assertEqual(mock_get.call_args_list[2].kwargs["params"]["nextPageToken"], "next-2")
+
+    @patch.dict(os.environ, REST_ENV, clear=False)
+    @patch("jira_utils.requests.get")
+    def test_search_result_surfaces_partial_page_failure(self, mock_get):
+        mock_get.side_effect = [
+            FakeResponse(200, {"issues": [{"id": "1", "key": "A-1"}], "nextPageToken": "next"}),
+            FakeResponse(403, {}),
+        ]
+
+        result = search_jira_issues_raw("updated >= '2024-01-01'", ["summary"])
+
+        self.assertFalse(result.complete)
+        self.assertEqual([issue["key"] for issue in result.issues], ["A-1"])
+        self.assertIn("page 2 failed", result.limitations[0])
+
+    @patch.dict(os.environ, REST_ENV, clear=False)
+    @patch("jira_utils.requests.get")
+    def test_get_jira_field_metadata_retains_ids_and_names(self, mock_get):
+        mock_get.return_value = FakeResponse(
+            200,
+            [{"id": "parent", "name": "Parent"}, {"id": "customfield_1", "name": "Epic Link"}],
+        )
+
+        result = get_jira_field_metadata()
+
+        self.assertTrue(result.complete)
+        self.assertEqual(result.fields[1]["id"], "customfield_1")
+        self.assertEqual(result.fields[1]["name"], "Epic Link")
+
+    @patch.dict(os.environ, REST_ENV, clear=False)
+    @patch("jira_utils.requests.post")
+    def test_bulk_changelog_fetch_splits_issue_batches_at_1000(self, mock_post):
+        def respond(_url, **kwargs):
+            containers = [
+                {"issueId": issue_key, "changeHistories": []} for issue_key in kwargs["json"]["issueIdsOrKeys"]
+            ]
+            return FakeResponse(200, {"issueChangeLogs": containers})
+
+        mock_post.side_effect = respond
+        issue_keys = [f"PROJ-{number}" for number in range(1, 1002)]
+
+        result = fetch_complete_changelogs(issue_keys)
+
+        self.assertTrue(result.complete)
+        self.assertEqual(mock_post.call_count, 2)
+        self.assertEqual(len(mock_post.call_args_list[0].kwargs["json"]["issueIdsOrKeys"]), 1000)
+        self.assertEqual(len(mock_post.call_args_list[1].kwargs["json"]["issueIdsOrKeys"]), 1)
+
+    @patch.dict(os.environ, REST_ENV, clear=False)
+    @patch("jira_utils.requests.post")
+    def test_bulk_changelog_fetch_paginates_every_next_page_token(self, mock_post):
+        history = {
+            "id": "h-1",
+            "created": "2024-01-01T00:00:00.000+0000",
+            "author": {"displayName": "Alice", "accountId": "account-1"},
+            "items": [
+                {
+                    "field": "Parent",
+                    "fieldId": "parent",
+                    "from": None,
+                    "fromString": None,
+                    "to": "100",
+                    "toString": "EPIC-1",
+                }
+            ],
+        }
+        mock_post.side_effect = [
+            FakeResponse(
+                200,
+                {
+                    "issueChangeLogs": [{"issueId": "1", "changeHistories": [history]}],
+                    "nextPageToken": "page-2",
+                },
+            ),
+            FakeResponse(200, {"issueChangeLogs": [{"issueId": "1", "changeHistories": []}]}),
+        ]
+
+        result = fetch_complete_changelogs(["1"], {"1": "PROJ-1"})
+
+        self.assertTrue(result.complete)
+        self.assertEqual(result.method, "bulk")
+        self.assertEqual(mock_post.call_args_list[1].kwargs["json"]["nextPageToken"], "page-2")
+        retained = result.records_by_issue["PROJ-1"][0]
+        self.assertEqual(retained["author"]["accountId"], "account-1")
+        self.assertEqual(retained["items"][0]["to"], "100")
+
+    @patch.dict(os.environ, REST_ENV, clear=False)
+    @patch("jira_utils.requests.get")
+    @patch("jira_utils.requests.post")
+    def test_bulk_unavailable_falls_back_to_paginated_per_issue_fetch(self, mock_post, mock_get):
+        mock_post.return_value = FakeResponse(404, {})
+        mock_get.side_effect = [
+            FakeResponse(200, {"values": [{"id": "one"}], "startAt": 0, "maxResults": 1, "total": 2}),
+            FakeResponse(200, {"values": [{"id": "two"}], "startAt": 1, "maxResults": 1, "total": 2}),
+        ]
+
+        result = fetch_complete_changelogs(["PROJ-1"])
+
+        self.assertTrue(result.complete)
+        self.assertEqual(result.method, "per-issue fallback")
+        self.assertEqual([item["id"] for item in result.records_by_issue["PROJ-1"]], ["one", "two"])
+        self.assertEqual(mock_get.call_args_list[1].kwargs["params"]["startAt"], 1)
+
+    @patch.dict(os.environ, REST_ENV, clear=False)
+    @patch("jira_utils.requests.get")
+    @patch("jira_utils.requests.post")
+    def test_per_issue_fallback_rejects_repeated_or_regressed_pages(self, mock_post, mock_get):
+        mock_post.return_value = FakeResponse(404, {})
+
+        for returned_start in (0, 1):
+            with self.subTest(returned_start=returned_start):
+                mock_get.reset_mock()
+                mock_get.side_effect = [
+                    FakeResponse(
+                        200,
+                        {
+                            "values": [{"id": "one"}, {"id": "two"}],
+                            "startAt": 0,
+                            "total": 3,
+                        },
+                    ),
+                    FakeResponse(
+                        200,
+                        {
+                            "values": [{"id": "repeated"}],
+                            "startAt": returned_start,
+                            "total": 3,
+                        },
+                    ),
+                ]
+
+                result = fetch_complete_changelogs(["PROJ-1"])
+
+                self.assertFalse(result.complete)
+                self.assertEqual(mock_get.call_count, 2)
+                self.assertIn("requested startAt 2", " ".join(result.limitations))
+                self.assertIn(f"returned {returned_start}", " ".join(result.limitations))
+
+    @patch.dict(os.environ, REST_ENV, clear=False)
+    @patch("jira_utils.requests.get")
+    @patch("jira_utils.requests.post")
+    def test_per_issue_fallback_rejects_contradictory_terminal_metadata(self, mock_post, mock_get):
+        mock_post.return_value = FakeResponse(404, {})
+
+        contradictory_pages = (
+            {"values": [{"id": "one"}], "startAt": 0, "total": 2, "isLast": True},
+            {"values": [{"id": "one"}], "startAt": 0, "total": 1, "isLast": False},
+        )
+        for page in contradictory_pages:
+            with self.subTest(page=page):
+                mock_get.reset_mock()
+                mock_get.return_value = FakeResponse(200, page)
+
+                result = fetch_complete_changelogs(["PROJ-1"])
+
+                self.assertFalse(result.complete)
+                self.assertEqual(mock_get.call_count, 1)
+                self.assertIn("contradictory pagination metadata", " ".join(result.limitations))
+
+    @patch.dict(os.environ, REST_ENV, clear=False)
+    @patch("jira_utils.requests.get")
+    @patch("jira_utils.requests.post")
+    def test_per_issue_fallback_requires_reliable_page_termination(self, mock_post, mock_get):
+        mock_post.return_value = FakeResponse(404, {})
+        mock_get.return_value = FakeResponse(200, {"values": [], "startAt": 0, "isLast": False})
+
+        result = fetch_complete_changelogs(["PROJ-1"])
+
+        self.assertFalse(result.complete)
+        self.assertIn("before the final page", " ".join(result.limitations))
+
+    @patch.dict(os.environ, REST_ENV, clear=False)
+    @patch("jira_utils.requests.get")
+    @patch("jira_utils.requests.post")
+    def test_later_bulk_page_failure_preserves_records_and_falls_back_without_duplicates(self, mock_post, mock_get):
+        history = {"id": "one", "created": "2024-01-01T00:00:00.000+0000", "items": []}
+        mock_post.side_effect = [
+            FakeResponse(
+                200,
+                {
+                    "issueChangeLogs": [{"issueId": "PROJ-1", "changeHistories": [history]}],
+                    "nextPageToken": "next",
+                },
+            ),
+            FakeResponse(403, {}),
+        ]
+        mock_get.return_value = FakeResponse(
+            200,
+            {"values": [history], "startAt": 0, "total": 1, "isLast": True},
+        )
+
+        result = fetch_complete_changelogs(["PROJ-1"])
+
+        self.assertFalse(result.complete)
+        self.assertEqual(result.method, "mixed bulk and per-issue fallback")
+        self.assertEqual(result.records_by_issue["PROJ-1"], [history])
+        self.assertIn("Bulk changelog page failed", " ".join(result.limitations))
+
+    @patch.dict(os.environ, REST_ENV, clear=False)
+    @patch("jira_utils.requests.get")
+    @patch("jira_utils.requests.post")
+    def test_missing_requested_issue_uses_fallback_and_unresolved_failure_is_incomplete(self, mock_post, mock_get):
+        mock_post.return_value = FakeResponse(
+            200,
+            {"issueChangeLogs": [{"issueId": "PROJ-1", "changeHistories": []}]},
+        )
+        mock_get.return_value = FakeResponse(403, {})
+
+        result = fetch_complete_changelogs(["PROJ-1", "PROJ-2"])
+
+        self.assertFalse(result.complete)
+        self.assertEqual(mock_get.call_count, 1)
+        self.assertIn("PROJ-2", " ".join(result.limitations))


### PR DESCRIPTION
## ⭐ Why this matters

Teams can now reconstruct when Jira issues entered, left, or moved between epics using complete changelog evidence instead of relying on the current child list. This provides an auditable historical view while clearly identifying permission or retrieval limitations.

---

## Summary

Add a standalone Jira CLI that audits historical epic membership changes across accessible projects.

- Supports auditing one epic or every currently labeled epic.
- Preserves raw changelog evidence and exports the same event data to CSV.
- Uses DST-aware Mountain time for date-only boundaries by default.

## Changes

- **Audit behavior**:
  - Add `jira_metrics/epic_membership_history.py` with mutually exclusive `--epic` and `--label` selectors.
  - Classify additions, removals, moves, and later re-additions from issue-level changelogs.
  - Resolve Parent, Epic Link, IssueParentAssociation, and dynamically discovered legacy fields.
  - Print the interpreted inclusive interval before contacting Jira.

- **Jira retrieval**:
  - Add complete bulk changelog retrieval with pagination, batching, and per-issue fallback.
  - Preserve history IDs, actors, field identifiers, and raw transition values.
  - Surface incomplete pages and inaccessible data without silently claiming completeness.
  - Correctly interpret Jira’s omission of requested null relationship fields as no current epic.

- **Reporting**:
  - Display chronological, width-limited event cards without horizontal scrolling.
  - Include per-epic and overall membership-change summaries.
  - Export matching flat event-level data through `--csv`.
  - Deduplicate repeated retrieval notes.

- **Tests and documentation**:
  - Add focused classification, pagination, cutoff, selector, reporting, and failure-path tests.
  - Document CLI examples, timezone behavior, output, and historical-label limitations in `README.md`.

## Validation

- [x] `python3 -m pytest -q` — 272 tests and 12 subtests passed.
- [x] `python3 -m black --check jira_metrics/epic_membership_history.py jira_metrics/jira_utils.py jira_metrics/tests/test_epic_membership_history.py jira_metrics/tests/test_jira_utils.py`
- [x] `python3 -m pylint jira_metrics/epic_membership_history.py jira_metrics/jira_utils.py jira_metrics/tests/test_epic_membership_history.py jira_metrics/tests/test_jira_utils.py` — 9.76/10.
- [x] **Live read-only Jira walkthrough**: Prerequisites: repository `.env` containing valid Jira credentials and an accessible epic key. Action: run `python3 jira_metrics/epic_membership_history.py --epic <EPIC_KEY> --since <YYYY-MM-DD>`. Expected and observed: the CLI prints the resolved Mountain-time interval before retrieval, renders chronological event cards without horizontal scrolling, completes paginated changelog retrieval, and clearly reports audit completeness.

Watch for: Jira’s bulk changelog endpoint may omit requested issues; the CLI transparently uses the complete per-issue fallback, which can make broad audits slower.

## Notes

- Label selection discovers only accessible epics currently carrying the label; previously removed labels cannot be reconstructed through the selector.
- Permission-restricted projects, issues, or changelog entries cannot be enumerated.
- Date-only inputs use `America/Denver`; full timestamps must include an explicit offset or `Z`.

<pre>
     ▐▛███▜▌
    ▝▜█████▛▘
      ▘▘ ▝▝
Quest/Co-Authored by
Co-Authored-By: GPT-5.6 Sol &lt;noreply@openai.com&gt;
Co-Authored-By: GPT-5.6 Terra &lt;noreply@openai.com&gt;
Co-Authored-By: Claude Opus 4.8 &lt;noreply@anthropic.com&gt;
in collaboration with KjellKod
</pre>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/KjellKod/metrics-and-insights/pull/147?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

