### PR TITLE
Retry transient GitHub API failures

### DIFF
--- a/.quest-manifest
+++ b/.quest-manifest
@@ -5,6 +5,7 @@
 [copy-as-is]
 # These files are replaced with upstream version (if unmodified locally)
 .quest-manifest
+.ai/context_digest.md
 .ai/quest.md
 .skills/quest/agents/README.md
 .skills/quest/agents/arbiter.md
@@ -67,6 +68,7 @@ docs/guides/quest_setup.md
 .skills/SKILLS.md
 .skills/ci-code-reviewer/SKILL.md
 .skills/code-reviewer/SKILL.md
+.skills/engineering-throughput-spreadsheet/SKILL.md
 .skills/pre-commit-review/SKILL.md
 .skills/git-commit-assistant/SKILL.md
 .skills/pr-assistant/SKILL.md

--- a/git_metrics/README.md
+++ b/git_metrics/README.md
@@ -117,7 +117,8 @@ Options:
 Environment configuration:
 - `CI_MATURITY_AGENTIC_PATTERNS`: Optional comma-separated patterns for agentic CI detection.
 
-When GitHub API rate limits are hit, the script honors `Retry-After` or waits until `X-RateLimit-Reset` before retrying.
+When GitHub API rate limits are hit, the script honors `Retry-After` or waits until `X-RateLimit-Reset` before retrying. Transient server errors, connection failures, and timeouts are retried with bounded exponential backoff.
+GitHub owner names are matched case-insensitively when reusing cached results.
 When cached repository results are reused, table and CSV runs print a reminder to re-run with `--force-fresh` for fresh GitHub data.
 Table and CSV output include likely responsible people based on recent distinct merged PR authors, with public profile names when available.
 JSON output includes per-repo scores, grade labels, responsible people, category evidence, skipped repositories, and rate-limit wait metadata.

--- a/git_metrics/ci_maturity_report.py
+++ b/git_metrics/ci_maturity_report.py
@@ -26,6 +26,8 @@ load_dotenv()
 GITHUB_REST_URL = "https://api.github.com"
 DEFAULT_TOKEN_ENV = "GITHUB_TOKEN_READONLY_WEB"
 DEFAULT_CACHE_FILE = ".ci_maturity_cache.json"
+TRANSIENT_HTTP_STATUS_CODES = frozenset({500, 502, 503, 504})
+MAX_TRANSIENT_RETRY_DELAY_SECONDS = 30.0
 
 LINTER_PATTERNS = (
     "lint",
@@ -136,16 +138,41 @@ class GitHubClient:
     def get(self, path_or_url: str, *, params: dict[str, Any] | None = None) -> requests.Response:
         url = path_or_url if path_or_url.startswith("https://") else f"{GITHUB_REST_URL}{path_or_url}"
         for attempt in range(1, self.max_retries + 1):
-            response = self.session.get(url, params=params, timeout=60)
-            if not self._should_wait_for_rate_limit(response) or attempt == self.max_retries:
-                if response.status_code == 401:
-                    raise RuntimeError(
-                        f"GitHub rejected token from {self.auth_source} with 401 Unauthorized. "
-                        "Refresh that token or confirm it is valid for api.github.com."
-                    )
-                response.raise_for_status()
-                return response
-            self._wait_for_rate_limit(response, url)
+            try:
+                response = self.session.get(url, params=params, timeout=60)
+            except (requests.ConnectionError, requests.Timeout) as exc:
+                if attempt == self.max_retries:
+                    raise
+                self._wait_for_transient_failure(
+                    url,
+                    attempt,
+                    reason=f"{type(exc).__name__}: {exc}",
+                )
+                continue
+
+            if response.status_code == 401:
+                raise RuntimeError(
+                    f"GitHub rejected token from {self.auth_source} with 401 Unauthorized. "
+                    "Refresh that token or confirm it is valid for api.github.com."
+                )
+            if self._should_wait_for_rate_limit(response):
+                if attempt == self.max_retries:
+                    response.raise_for_status()
+                self._wait_for_rate_limit(response, url)
+                continue
+            if response.status_code in TRANSIENT_HTTP_STATUS_CODES:
+                if attempt == self.max_retries:
+                    response.raise_for_status()
+                self._wait_for_transient_failure(
+                    url,
+                    attempt,
+                    reason=f"{response.status_code} {response.reason}",
+                    response=response,
+                )
+                continue
+
+            response.raise_for_status()
+            return response
         raise RuntimeError(f"GitHub request failed after {self.max_retries} attempts: {url}")
 
     def get_json(self, path_or_url: str, *, params: dict[str, Any] | None = None) -> Any:
@@ -432,6 +459,30 @@ class GitHubClient:
                 slept_seconds=sleep_seconds,
                 reset_at=reset_at,
             )
+        )
+        self.sleep_fn(sleep_seconds)
+
+    def _wait_for_transient_failure(
+        self,
+        url: str,
+        attempt: int,
+        *,
+        reason: str,
+        response: requests.Response | None = None,
+    ) -> None:
+        retry_after = response.headers.get("Retry-After") if response is not None else None
+        try:
+            sleep_seconds = float(retry_after) if retry_after is not None else 2 ** (attempt - 1)
+        except ValueError:
+            sleep_seconds = 2 ** (attempt - 1)
+        sleep_seconds = min(MAX_TRANSIENT_RETRY_DELAY_SECONDS, max(0.0, sleep_seconds))
+        logging.getLogger(__name__).warning(
+            "Transient GitHub request failure (%s); retrying in %.1f seconds (%d/%d): %s",
+            reason,
+            sleep_seconds,
+            attempt,
+            self.max_retries,
+            url,
         )
         self.sleep_fn(sleep_seconds)
 
@@ -761,8 +812,10 @@ def load_cache(
         return {"repositories": {}}
     if not isinstance(payload, dict):
         return {"repositories": {}}
+    cached_owner = payload.get("owner")
+    owner_matches = isinstance(cached_owner, str) and cached_owner.casefold() == owner.casefold()
     if (
-        payload.get("owner") != owner
+        not owner_matches
         or payload.get("active_days") != active_days
         or payload.get("responsible_count") != responsible_count
         or payload.get("responsible_pr_scan_limit") != responsible_pr_scan_limit

--- a/tests/unit/git_metrics/test_ci_maturity_report.py
+++ b/tests/unit/git_metrics/test_ci_maturity_report.py
@@ -5,6 +5,7 @@ import json
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
+import pytest
 import requests
 
 from git_metrics.ci_maturity_report import (
@@ -16,10 +17,11 @@ from git_metrics.ci_maturity_report import (
     emit_report,
     filter_repositories,
     format_responsible_people,
-    merge_external_ci_evidence,
+    load_cache,
     load_token,
-    parse_patterns,
+    merge_external_ci_evidence,
     parse_csv_values,
+    parse_patterns,
     render_table,
     score_workflows,
 )
@@ -250,6 +252,82 @@ def test_rate_limit_wait_uses_retry_after_before_reset_header() -> None:
     assert client.rate_limit_events[0].reset_at is None
 
 
+def test_get_retries_transient_bad_gateway_then_returns_success(monkeypatch) -> None:
+    sleeps: list[float] = []
+    client = GitHubClient("token", sleep_fn=sleeps.append)
+    responses = []
+    for status_code in (502, 200):
+        response = requests.Response()
+        response.status_code = status_code
+        response.reason = "Bad Gateway" if status_code == 502 else "OK"
+        response.url = "https://api.github.com/test"
+        responses.append(response)
+    calls = 0
+
+    def scripted_get(*args, **kwargs):
+        nonlocal calls
+        response = responses[calls]
+        calls += 1
+        return response
+
+    monkeypatch.setattr(client.session, "get", scripted_get)
+
+    response = client.get("/test")
+
+    assert response.status_code == 200
+    assert calls == 2
+    assert sleeps == [1.0]
+
+
+def test_get_retries_connection_timeout_then_returns_success(monkeypatch) -> None:
+    sleeps: list[float] = []
+    client = GitHubClient("token", sleep_fn=sleeps.append)
+    response = requests.Response()
+    response.status_code = 200
+    response.url = "https://api.github.com/test"
+    outcomes = [requests.Timeout("timed out"), response]
+    calls = 0
+
+    def scripted_get(*args, **kwargs):
+        nonlocal calls
+        outcome = outcomes[calls]
+        calls += 1
+        if isinstance(outcome, Exception):
+            raise outcome
+        return outcome
+
+    monkeypatch.setattr(client.session, "get", scripted_get)
+
+    result = client.get("/test")
+
+    assert result.status_code == 200
+    assert calls == 2
+    assert sleeps == [1.0]
+
+
+def test_get_stops_after_configured_transient_retry_limit(monkeypatch) -> None:
+    sleeps: list[float] = []
+    client = GitHubClient("token", sleep_fn=sleeps.append, max_retries=3)
+    response = requests.Response()
+    response.status_code = 503
+    response.reason = "Service Unavailable"
+    response.url = "https://api.github.com/test"
+    calls = 0
+
+    def always_unavailable(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        return response
+
+    monkeypatch.setattr(client.session, "get", always_unavailable)
+
+    with pytest.raises(requests.HTTPError, match="503 Server Error"):
+        client.get("/test")
+
+    assert calls == 3
+    assert sleeps == [1.0, 2.0]
+
+
 class StubGitHubClient(GitHubClient):
     def __init__(self, payloads: dict[str, object]) -> None:
         super().__init__("token")
@@ -381,6 +459,36 @@ def test_load_token_uses_configured_env_var(monkeypatch) -> None:
     monkeypatch.setenv("GITHUB_TOKEN_READONLY_WEB", " test-token ")
 
     assert load_token("GITHUB_TOKEN_READONLY_WEB") == "test-token"
+
+
+def test_load_cache_matches_github_owner_case_insensitively(tmp_path: Path) -> None:
+    cache_path = tmp_path / "cache.json"
+    cached_repo = {"name": "ExampleOrg/api-service", "score": 4}
+    cache_path.write_text(
+        json.dumps(
+            {
+                "owner": "exampleorg",
+                "active_days": 90,
+                "responsible_count": 2,
+                "responsible_pr_scan_limit": 30,
+                "ci_pr_scan_limit": 5,
+                "repositories": {"ExampleOrg/api-service": cached_repo},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    cache = load_cache(
+        str(cache_path),
+        force_fresh=False,
+        owner="ExampleOrg",
+        active_days=90,
+        responsible_count=2,
+        responsible_pr_scan_limit=30,
+        ci_pr_scan_limit=5,
+    )
+
+    assert cache["repositories"]["ExampleOrg/api-service"] == cached_repo
 
 
 def test_json_output_includes_score_evidence_skipped_and_rate_limit_metadata(tmp_path: Path) -> None:


### PR DESCRIPTION
## ⭐ Why this matters
Organization-wide CI maturity reports no longer stop immediately when a brief API, server, or network interruption occurs. Cached results also remain reusable when owner-name casing varies.

---

## Summary
Adds bounded retries for transient GitHub API failures and case-insensitive cache-owner matching so reports complete more reliably.
- Persistent failures still surface as errors instead of producing misleading CI scores.
- Existing cache configuration and output formats remain compatible.

## Changes
- **Reliability**:
  - Retry `500`, `502`, `503`, and `504` responses with bounded exponential backoff.
  - Retry connection failures and timeouts while honoring `Retry-After` when provided.
- **Cache behavior**:
  - Match repository owner names case-insensitively when loading cached results.
- **Tests and documentation**:
  - Cover transient recovery, timeout recovery, retry exhaustion, and cache-owner casing.
  - Document the retry and cache behavior.
- **Maintenance**:
  - Register existing managed files required by the repository manifest gate.

## Validation
- [x] Run `python3 -m pytest -q tests/unit/git_metrics/test_ci_maturity_report.py`; all 25 tests pass.
- [x] Run `python3 -m pytest -q`; all 278 tests and 12 subtests pass.
- [x] Run Black, isort, manifest validation, and `git diff --check`; all pass.

Watch for: persistent server failures must still raise after the configured attempt limit.

<pre>
     ▐▛███▜▌
    ▝▜█████▛▘
      ▘▘ ▝▝
Quest/Co-Authored by
Co-Authored-By: Codex <noreply@openai.com>
in collaboration with KjellKod
</pre>

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/KjellKod/metrics-and-insights/pull/149?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

